### PR TITLE
Fix bug with notifications getting disabled

### DIFF
--- a/cogs/bear_trap.py
+++ b/cogs/bear_trap.py
@@ -215,12 +215,13 @@ class BearTrap(commands.Cog):
 
             channel = self.bot.get_channel(channel_id)
             if not channel:
-                self.cursor.execute("""
-                    UPDATE bear_notifications 
-                    SET is_enabled = 0 
-                    WHERE id = ?
-                """, (id,))
-                self.conn.commit()
+                print(f"Warning: Channel {channel_id} not found for notification {id}.")
+                # self.cursor.execute("""
+                #     UPDATE bear_notifications 
+                #     SET is_enabled = 0 
+                #     WHERE id = ?
+                # """, (id,))
+                # self.conn.commit()
                 return
 
             tz = pytz.timezone(timezone)


### PR DESCRIPTION
This *should* fix the issue with event notifications being spontaneously disabled for bot users.

The root cause seems to be a check for whether the channel for a notification can be found in the notification processor. If it cannot be found, the code would disable the respective event notification.

The problem with that logic is that a channel may be unavailable for reasons other than it not existing - for example, it might not be reachable at the moment due to the bot hitting Discord's API rate limits, especially on a shared hosting solution like Lunes. That would also result in all notifications ending up disabled.

The fix prints out a warning if the channel is unavailable and comments out the logic to disable the notification in this case for now.