### PR TITLE
docker: support for --beta and --no-update

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,16 +1,28 @@
 #!/bin/sh
 
-echo "[WSDB] For more information please see https://github.com/whiteout-project/bot"
+echo "[WSDB] for more information please see https://github.com/whiteout-project/bot"
 
 cd /app
 
-if [ ! -n "${DISCORD_BOT_TOKEN}" ]; then
-	echo "please set DISCORD_BOT_TOKEN"
-	exit
+if [ -z "${DISCORD_BOT_TOKEN}" ]; then
+    echo "please set DISCORD_BOT_TOKEN"
+    exit 1
 fi
 
-if [ -n "${DISCORD_BOT_TOKEN}" ]; then
-    echo "${DISCORD_BOT_TOKEN}" > bot_token.txt
+echo "${DISCORD_BOT_TOKEN}" > bot_token.txt
+
+if [ "${UPDATE}" = "0" ]; then
+    ARGS="--no-update"
+else
+	ARGS="--autoupdate"
 fi
 
-python main.py --autoupdate
+if [ "${BETA}" = "1" ]; then
+    ARGS="$ARGS --beta"
+fi
+
+if [ "${DEBUG}" = "1" ]; then
+    ARGS="$ARGS --debug"
+fi
+
+python main.py $ARGS


### PR DESCRIPTION
added support for:
- the `--beta` flag, with environment variable `BETA=1`
- the `--no-update` flag, with environment variable `UPDATE=0`
- the `--debug` flag, with environment variable `DEBUG=1`