### PR TITLE
Do not unconditionally call .strip() on a response that may not be a string.

### DIFF
--- a/cogs/gift_operations.py
+++ b/cogs/gift_operations.py
@@ -1132,7 +1132,7 @@ class GiftOperations(commands.Cog):
             self.giftlog.info(log_entry_redeem.strip())
             
             # Parse response
-            msg = response_json_redeem.get("msg", "Unknown Error").strip('.')
+            msg = str(response_json_redeem.get("msg", "Unknown Error")).strip('.')
             err_code = response_json_redeem.get("err_code")
             
             # Check if this is a rate limit error - these need special handling


### PR DESCRIPTION
Fixes #60.

I encountered an instance where the response from WOS from a gift code redemption was that 'msg' was an int.  The standard error handling in the bot did not run because .strip() threw an AttributeError.  This will ensure that no AttributeError occurs and the standard bot error handling takes place instead.