### PR TITLE
added support for hour/day/month units in history searches

### DIFF
--- a/cogs/changes.py
+++ b/cogs/changes.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 import sqlite3
-from datetime import datetime
+import re
 from .alliance_member_operations import AllianceSelectView
 from .permission_handler import PermissionManager
 from .pimp_my_bot import theme
@@ -226,7 +226,12 @@ class Changes(commands.Cog):
                 ephemeral=True
             )
 
-    async def show_recent_changes(self, interaction: discord.Interaction, alliance_name: str, hours: int):
+    async def show_recent_changes(self, interaction: discord.Interaction, alliance_name: str, match: re.Match):
+        time_multipliers = {"h": 1, "d": 24, "mo": 24 * 30}
+        time_dict = {"h": "hour(s)", "d": "day(s)", "mo": "month(s)"}
+        hours = int(match.groups()[0]) * time_multipliers[match.groups()[1]]
+        human_readable_time = f"{match.groups()[0]} {time_dict[match.groups()[1]]}"
+        
         try:
             with sqlite3.connect('db/alliance.sqlite') as alliance_db:
                 cursor = alliance_db.cursor()
@@ -254,14 +259,14 @@ class Changes(commands.Cog):
 
             if not changes:
                 await interaction.followup.send(
-                    f"No level changes found in the last {hours} hour(s) for {alliance_name}.",
+                    f"No level changes found in the last {human_readable_time} for {alliance_name}.",
                     ephemeral=True
                 )
                 return
 
             chunks = [changes[i:i + 25] for i in range(0, len(changes), 25)]
             
-            view = RecentChangesView(chunks, members, self.level_mapping, alliance_name, hours)
+            view = RecentChangesView(chunks, members, self.level_mapping, alliance_name, human_readable_time)
             await interaction.followup.send(embed=view.get_embed(), view=view)
 
         except Exception as e:
@@ -271,7 +276,12 @@ class Changes(commands.Cog):
                 ephemeral=True
             )
 
-    async def show_recent_nickname_changes(self, interaction: discord.Interaction, alliance_name: str, hours: int):
+    async def show_recent_nickname_changes(self, interaction: discord.Interaction, alliance_name: str, match: re.Match):
+        time_multipliers = {"h": 1, "d": 24, "mo": 24 * 30}
+        time_dict = {"h": "hour(s)", "d": "day(s)", "mo": "month(s)"}
+        hours = int(match.groups()[0]) * time_multipliers[match.groups()[1]]
+        human_readable_time = f"{match.groups()[0]} {time_dict[match.groups()[1]]}"
+        
         try:
             with sqlite3.connect('db/alliance.sqlite') as alliance_db:
                 cursor = alliance_db.cursor()
@@ -299,14 +309,14 @@ class Changes(commands.Cog):
 
             if not changes:
                 await interaction.followup.send(
-                    f"No nickname changes found in the last {hours} hour(s) for {alliance_name}.",
+                    f"No nickname changes found in the last {human_readable_time} for {alliance_name}.",
                     ephemeral=True
                 )
                 return
 
             chunks = [changes[i:i + 25] for i in range(0, len(changes), 25)]
             
-            view = RecentNicknameChangesView(chunks, members, alliance_name, hours)
+            view = RecentNicknameChangesView(chunks, members, alliance_name, human_readable_time)
             await interaction.followup.send(embed=view.get_embed(), view=view)
 
         except Exception as e:
@@ -568,7 +578,7 @@ class HistoryView(discord.ui.View):
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
-            await self.cog.show_recent_changes(interaction, self.alliance_name, hours=1)
+            await self.cog.show_recent_changes(interaction, self.alliance_name, re.match(r"^(\d+)(h|d|mo)$", "1h"))
         except Exception as e:
             print(f"Error in last_hour_callback: {e}")
             if not interaction.response.is_done():
@@ -586,7 +596,7 @@ class HistoryView(discord.ui.View):
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
-            await self.cog.show_recent_changes(interaction, self.alliance_name, hours=24)
+            await self.cog.show_recent_changes(interaction, self.alliance_name, re.match(r"^(\d+)(h|d|mo)$", "24h"))
         except Exception as e:
             print(f"Error in last_day_callback: {e}")
             if not interaction.response.is_done():
@@ -728,7 +738,7 @@ class MemberListView(discord.ui.View):
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
-            await self.cog.show_recent_changes(interaction, self.alliance_name, hours=1)
+            await self.cog.show_recent_changes(interaction, self.alliance_name, re.match(r"^(\d+)(h|d|mo)$", "1h"))
         except Exception as e:
             print(f"Error in last_hour_callback: {e}")
             if not interaction.response.is_done():
@@ -746,7 +756,7 @@ class MemberListView(discord.ui.View):
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
-            await self.cog.show_recent_changes(interaction, self.alliance_name, hours=24)
+            await self.cog.show_recent_changes(interaction, self.alliance_name, re.match(r"^(\d+)(h|d|mo)$", "24h"))
         except Exception as e:
             print(f"Error in last_day_callback: {e}")
             if not interaction.response.is_done():
@@ -954,7 +964,7 @@ class MemberListViewNickname(discord.ui.View):
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
-            await self.cog.show_recent_nickname_changes(interaction, self.alliance_name, hours=1)
+            await self.cog.show_recent_nickname_changes(interaction, self.alliance_name, re.match(r"^(\d+)(h|d|mo)$", "1h"))
         except Exception as e:
             print(f"Error in last_hour_callback: {e}")
             if not interaction.response.is_done():
@@ -972,7 +982,7 @@ class MemberListViewNickname(discord.ui.View):
         try:
             if not interaction.response.is_done():
                 await interaction.response.defer()
-            await self.cog.show_recent_nickname_changes(interaction, self.alliance_name, hours=24)
+            await self.cog.show_recent_nickname_changes(interaction, self.alliance_name, re.match(r"^(\d+)(h|d|mo)$", "24h"))
         except Exception as e:
             print(f"Error in last_day_callback: {e}")
             if not interaction.response.is_done():
@@ -1068,27 +1078,37 @@ class CustomTimeModal(discord.ui.Modal, title="Custom Time Range"):
         super().__init__()
         self.cog = cog
         self.alliance_name = alliance_name
-        self.hours = discord.ui.TextInput(
-            label="Hours (1-24)",
-            placeholder="Enter number of hours (max 24)...",
+        self.time_frame = discord.ui.TextInput(
+            label="Time Frame",
+            placeholder="eg. 24h, 3d, 2mo",
             required=True,
-            min_length=1,
-            max_length=2
+            min_length=2
         )
-        self.add_item(self.hours)
+        self.add_item(self.time_frame)
 
     async def on_submit(self, interaction: discord.Interaction):
         try:
-            hours = int(self.hours.value)
-            if hours < 1 or hours > 24:
+            time_frame = self.time_frame.value.strip().lower()
+            time_pattern = r"^(\d+)(h|d|mo)$"
+            
+            match = re.match(time_pattern, time_frame)
+            
+            if match and int(match.groups()[0]) < 1:
                 await interaction.response.send_message(
-                    f"{theme.deniedIcon} Please enter a number between 1 and 24.",
+                    f"{theme.deniedIcon} Please enter a number 1 or greater.",
+                    ephemeral=True
+                )
+                return
+            
+            if not match:
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Invalid format. Please enter a valid time frame (e.g. 24h, 3d, 2mo).",
                     ephemeral=True
                 )
                 return
             
             await interaction.response.defer()
-            await self.cog.show_recent_changes(interaction, self.alliance_name, hours)
+            await self.cog.show_recent_changes(interaction, self.alliance_name, match)
                 
         except ValueError:
             await interaction.response.send_message(
@@ -1103,13 +1123,13 @@ class CustomTimeModal(discord.ui.Modal, title="Custom Time Range"):
             )
 
 class RecentChangesView(discord.ui.View):
-    def __init__(self, chunks, members, level_mapping, alliance_name, hours):
+    def __init__(self, chunks, members, level_mapping, alliance_name, time):
         super().__init__()
         self.chunks = chunks
         self.members = members
         self.level_mapping = level_mapping
         self.alliance_name = alliance_name
-        self.hours = hours
+        self.time = time
         self.current_page = 0
         self.total_pages = len(chunks)
         
@@ -1119,7 +1139,7 @@ class RecentChangesView(discord.ui.View):
         embed = discord.Embed(
             title=f"{theme.levelIcon} Recent Level Changes - {self.alliance_name}",
             description=(
-                f"Showing changes in the last {self.hours} hour(s)\n"
+                f"Showing changes in the last {self.time}\n"
                 f"{theme.upperDivider}\n"
                 f"Total Changes: {sum(len(chunk) for chunk in self.chunks)}\n"
                 f"Page {self.current_page + 1}/{self.total_pages}\n"
@@ -1159,12 +1179,12 @@ class RecentChangesView(discord.ui.View):
         await interaction.response.edit_message(embed=self.get_embed(), view=self)
 
 class RecentNicknameChangesView(discord.ui.View):
-    def __init__(self, chunks, members, alliance_name, hours):
+    def __init__(self, chunks, members, alliance_name, time):
         super().__init__()
         self.chunks = chunks
         self.members = members
         self.alliance_name = alliance_name
-        self.hours = hours
+        self.time = time
         self.current_page = 0
         self.total_pages = len(chunks)
         
@@ -1174,7 +1194,7 @@ class RecentNicknameChangesView(discord.ui.View):
         embed = discord.Embed(
             title=f"{theme.editListIcon} Recent Nickname Changes - {self.alliance_name}",
             description=(
-                f"Showing changes in the last {self.hours} hour(s)\n"
+                f"Showing changes in the last {self.time}\n"
                 f"{theme.upperDivider}\n"
                 f"Total Changes: {sum(len(chunk) for chunk in self.chunks)}\n"
                 f"Page {self.current_page + 1}/{self.total_pages}\n"
@@ -1216,27 +1236,37 @@ class CustomTimeModalNickname(discord.ui.Modal, title="Custom Time Range"):
         super().__init__()
         self.cog = cog
         self.alliance_name = alliance_name
-        self.hours = discord.ui.TextInput(
-            label="Hours (1-24)",
-            placeholder="Enter number of hours (max 24)...",
+        self.time_frame = discord.ui.TextInput(
+            label="Time Frame",
+            placeholder="eg. 24h, 3d, 2mo",
             required=True,
-            min_length=1,
-            max_length=2
+            min_length=2
         )
-        self.add_item(self.hours)
+        self.add_item(self.time_frame)
 
     async def on_submit(self, interaction: discord.Interaction):
         try:
-            hours = int(self.hours.value)
-            if hours < 1 or hours > 24:
+            time_frame = self.time_frame.value.strip().lower()
+            time_pattern = r"^(\d+)(h|d|mo)$"
+            
+            match = re.match(time_pattern, time_frame)
+            
+            if match and int(match.groups()[0]) < 1:
                 await interaction.response.send_message(
-                    f"{theme.deniedIcon} Please enter a number between 1 and 24.",
+                    f"{theme.deniedIcon} Please enter a number 1 or greater.",
+                    ephemeral=True
+                )
+                return
+            
+            if not match:
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Invalid format. Please enter a valid time frame (e.g. 24h, 3d, 2mo).",
                     ephemeral=True
                 )
                 return
             
             await interaction.response.defer()
-            await self.cog.show_recent_nickname_changes(interaction, self.alliance_name, hours)
+            await self.cog.show_recent_nickname_changes(interaction, self.alliance_name, match)
                 
         except ValueError:
             await interaction.response.send_message(


### PR DESCRIPTION
added support for a wider range of inputs such as `1h` / `3d` / `2mo` (1 hour / 3 days / 2 months) in the custom time button for nickname and furnace level changes.

tested by both yolo and i and is ready for merging