### PR TITLE
fix: Enqueue auto-redeem operation on manual gift code entry

### DIFF
--- a/cogs/gift_operations.py
+++ b/cogs/gift_operations.py
@@ -1,5 +1,5 @@
 import discord
-from discord.ext import commands
+from discord.ext import commands, tasks
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -7,7 +7,6 @@ import hashlib
 import json
 from datetime import datetime
 import sqlite3
-from discord.ext import tasks
 import asyncio
 import base64
 import re
@@ -4613,16 +4612,22 @@ class CreateGiftCodeModal(discord.ui.Modal):
             
             if is_valid: # Valid code - send to API and add to DB
                 logger.info(f"[CreateGiftCodeModal] Code '{code}' validated successfully.")
-                
+
                 if hasattr(self.cog, 'api') and self.cog.api:
                     asyncio.create_task(self.cog.api.add_giftcode(code))
-                
+
+                await self.cog._process_auto_use(code)
+
+                self.cog.cursor.execute("SELECT COUNT(*) FROM giftcodecontrol WHERE status = 1")
+                auto_count = self.cog.cursor.fetchone()[0]
+
                 final_embed.title = f"{theme.verifiedIcon} Gift Code Validated"
                 final_embed.description = (
                     f"**Gift Code Details**\n{theme.upperDivider}\n"
                     f"{theme.giftIcon} **Gift Code:** `{code}`\n"
                     f"{theme.verifiedIcon} **Status:** {validation_msg}\n"
                     f"{theme.editListIcon} **Action:** Added to database and sent to API\n"
+                    f"{theme.refreshIcon} **Auto-redemption:** {'Queued for ' + str(auto_count) + ' alliance(s)' if auto_count else 'Disabled'}\n"
                     f"{theme.lowerDivider}\n"
                 )
                 final_embed.color = discord.Color.green()


### PR DESCRIPTION
Currently, the bot does not enqueue the alliances into auto-redeeming the newly added code, if the code is added from the Add Gift Code option in the Bot's setting menu. The sync from the external DB skips the newly added code entirely due to how the code currently works. Hence we need to explicitly call the process function after a code is manually added.