### PR TITLE
Main.py cleanup

### DIFF
--- a/cogs/bot_health.py
+++ b/cogs/bot_health.py
@@ -19,6 +19,7 @@ from packaging.version import parse as parse_version
 import re
 from .permission_handler import PermissionManager
 from .pimp_my_bot import theme, safe_edit_message
+from .bot_restart import is_container, restart_process
 
 
 # Health status constants
@@ -30,30 +31,6 @@ STATUS_ERROR = "error"
 DB_SIZE_WARNING_MB = 100
 
 
-def is_container() -> bool:
-    """Check if running in a container (Docker, Kubernetes, Podman, LXC, systemd-nspawn)"""
-    # Docker, Kubernetes, Podman - simple marker file checks
-    marker_files = ["/.dockerenv", "/var/run/secrets/kubernetes.io", "/run/.containerenv"]
-    if any(os.path.exists(path) for path in marker_files):
-        return True
-
-    # LXC - check init process environment
-    try:
-        with open("/proc/1/environ", "r") as f:
-            if "container=lxc" in f.read():
-                return True
-    except (IOError, OSError):
-        pass
-
-    # Systemd-nspawn - check container type file
-    try:
-        with open("/run/systemd/container", "r") as f:
-            if f.read().strip() == "systemd-nspawn":
-                return True
-    except (IOError, OSError):
-        pass
-
-    return False
 DB_SIZE_ERROR_MB = 500
 WAL_SIZE_WARNING_MB = 1
 WAL_SIZE_ERROR_MB = 10
@@ -94,6 +71,7 @@ HELPER_FILES = [
     'pimp_my_bot_editor',      # Theme editor utilities
     'pimp_my_bot_preview',     # Theme preview utilities
     'onnx_lifecycle',          # OCR model lazy-load + eviction (explicit safelist)
+    'bot_restart',             # Shared platform-aware restart helper
     '__init__',                # Package init file
 ]
 
@@ -791,6 +769,7 @@ class BotHealth(commands.Cog):
             'logs_archived': 0,
             'legacy_artifacts_removed': [],
             'legacy_packages_removed': [],
+            'requirements_cleaned': [],
             'errors': []
         }
 
@@ -821,6 +800,12 @@ class BotHealth(commands.Cog):
         except Exception as e:
             results['errors'].append(f"Legacy packages: {e}")
             self.logger.error(f"Cleanup legacy packages error: {e}")
+
+        try:
+            results['requirements_cleaned'] = self._strip_obsolete_requirements()
+        except Exception as e:
+            results['errors'].append(f"Requirements cleanup: {e}")
+            self.logger.error(f"Cleanup requirements error: {e}")
 
         self.update_config(last_cleanup_date=datetime.now(timezone.utc).date().isoformat())
 
@@ -859,6 +844,16 @@ class BotHealth(commands.Cog):
                         removed.append(entry)
                 except Exception as e:
                     self.logger.warning(f"Could not remove {entry}: {e}")
+
+        # Developer-only `tests/` dir: export-ignored from releases, so it should
+        # never be in a production install. Remove it there, but leave it alone
+        # in a git checkout (presence of `.git`) so developers keep their tests.
+        if os.path.isdir("tests") and not os.path.isdir(".git"):
+            try:
+                shutil.rmtree("tests", onerror=self._on_rmtree_error)
+                removed.append("tests")
+            except Exception as e:
+                self.logger.warning(f"Could not remove tests dir: {e}")
 
         return removed
 
@@ -901,6 +896,36 @@ class BotHealth(commands.Cog):
                 self.logger.warning(f"Could not uninstall {pkg}: {e}")
 
         return removed
+
+    def _strip_obsolete_requirements(self) -> list:
+        """Remove any LEGACY_PACKAGES_TO_REMOVE entries from requirements.txt so
+        a later reinstall won't pull them back. Rewrites the file only when it
+        actually changes. Returns the package names that were stripped."""
+        path = "requirements.txt"
+        if not os.path.isfile(path):
+            return []
+
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        legacy = {p.lower() for p in LEGACY_PACKAGES_TO_REMOVE}
+        kept, stripped = [], []
+        for line in lines:
+            bare = line.strip()
+            if bare and not bare.startswith("#"):
+                name = bare
+                for sep in ("==", ">=", "<=", "~=", "!="):
+                    name = name.split(sep)[0]
+                if name.strip().lower() in legacy:
+                    stripped.append(name.strip().lower())
+                    continue
+            kept.append(line)
+
+        if stripped:
+            with open(path, "w", encoding="utf-8") as f:
+                f.writelines(kept)
+
+        return stripped
 
     async def _checkpoint_all_databases(self) -> list:
         """Checkpoint all databases"""
@@ -1296,39 +1321,8 @@ class BotHealth(commands.Cog):
         # Give Discord a moment to send the message
         await asyncio.sleep(1)
 
-        # Filter --no-update when relaunching for an update
-        relaunch_args = list(sys.argv)
-        if allow_update:
-            relaunch_args = [a for a in relaunch_args if a != "--no-update"]
-
-        if is_container():
-            self.logger.info("Exiting for container restart...")
-            sys.exit(0)
-
-        if is_windows_host:
-            # Print clear restart instructions for the host operator and exit.
-            venv_python = os.path.join("bot_venv", "Scripts", "python.exe")
-            cmd_parts = [
-                venv_python if os.path.exists(venv_python) else "python",
-                *sys.argv,
-            ]
-            if allow_update and "--no-update" in cmd_parts:
-                cmd_parts = [a for a in cmd_parts if a != "--no-update"]
-            print()
-            print("=" * 60)
-            print("  Bot stopped. To restart, run:")
-            print(f"    {' '.join(cmd_parts)}")
-            print("=" * 60)
-            print()
-            sys.exit(0)
-
         self.logger.info("Self-restarting...")
-        try:
-            os.execl(sys.executable, sys.executable, *relaunch_args)
-        except Exception as e:
-            self.logger.error(f"Self-restart failed: {e}")
-            print(f"Self-restart failed: {e}")
-            sys.exit(1)
+        restart_process(allow_update=allow_update)
 
     @commands.Cog.listener()
     async def on_ready(self):
@@ -1728,6 +1722,10 @@ class HealthMenuView(discord.ui.View):
         pkgs = results.get('legacy_packages_removed') or []
         if pkgs:
             result_parts.append(f"Uninstalled legacy package(s): {', '.join(pkgs)}")
+
+        reqs = results.get('requirements_cleaned') or []
+        if reqs:
+            result_parts.append(f"Removed obsolete requirements entries: {', '.join(reqs)}")
 
         if results['errors']:
             result_parts.append(f"\n{theme.warnIcon} Some issues: {', '.join(results['errors'][:2])}")

--- a/cogs/bot_restart.py
+++ b/cogs/bot_restart.py
@@ -1,0 +1,71 @@
+"""Shared, platform-aware process restart.
+
+Used by both the startup updater (main.py) and the in-app Restart button
+(cogs/bot_health.py) so there is a single source of truth for how the bot
+relaunches itself. Stdlib-only and side-effect-free so it is safe to import
+during main.py's early bootstrap and from a cog. Not a cog itself (no setup()).
+"""
+import os
+import sys
+
+
+def is_container() -> bool:
+    """Check if running in a container (Docker, Kubernetes, Podman, LXC, systemd-nspawn)."""
+    # Docker, Kubernetes, Podman - simple marker file checks
+    marker_files = ["/.dockerenv", "/var/run/secrets/kubernetes.io", "/run/.containerenv"]
+    if any(os.path.exists(path) for path in marker_files):
+        return True
+
+    # LXC - check init process environment
+    try:
+        with open("/proc/1/environ", "r") as f:
+            if "container=lxc" in f.read():
+                return True
+    except (IOError, OSError):
+        pass
+
+    # Systemd-nspawn - check container type file
+    try:
+        with open("/run/systemd/container", "r") as f:
+            if f.read().strip() == "systemd-nspawn":
+                return True
+    except (IOError, OSError):
+        pass
+
+    return False
+
+
+def restart_process(allow_update: bool = False):
+    """Restart the current bot process in a platform-aware way.
+
+    - Container: clean exit; the orchestrator (Docker/k8s) relaunches it.
+    - Windows host: print the run command and exit. Windows can't reliably
+      relaunch itself (a spawned child races the parent shell for stdin).
+    - Linux/Mac: os.execl() for in-place replacement.
+
+    One-shot flags (--repair, --no-venv) are filtered from the relaunch args
+    to avoid loops. --no-update is filtered only when allow_update is True, so
+    the startup updater can install a pending release on relaunch.
+    """
+    drop = {"--repair", "--no-venv"}
+    if allow_update:
+        drop.add("--no-update")
+    relaunch_args = [arg for arg in sys.argv if arg not in drop]
+
+    if is_container():
+        print("  Restarting bot...")
+        sys.exit(0)
+
+    if sys.platform == "win32":
+        venv_python = os.path.join("bot_venv", "Scripts", "python.exe")
+        python = venv_python if os.path.exists(venv_python) else "python"
+        print()
+        print("=" * 60)
+        print("  Bot stopped. To restart, run:")
+        print(f"    {python} {' '.join(relaunch_args)}")
+        print("=" * 60)
+        print()
+        sys.exit(0)
+
+    print("  Restarting bot...")
+    os.execl(sys.executable, sys.executable, *relaunch_args)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,9 @@ import sys
 import os
 import shutil
 import stat
+import contextlib
 from cogs import bot_startup_display as startup
+from cogs.bot_restart import is_container, restart_process
 
 # Python version check
 MIN_PYTHON = (3, 11)
@@ -11,30 +13,6 @@ MIN_PYTHON = (3, 11)
 if sys.version_info < MIN_PYTHON:
     startup.python_too_old(f"{MIN_PYTHON[0]}.{MIN_PYTHON[1]}", f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
     sys.exit(1)
-
-def is_container() -> bool:
-    # Docker, Kubernetes, Podman - simple marker file checks
-    marker_files = ["/.dockerenv", "/var/run/secrets/kubernetes.io", "/run/.containerenv"]
-    if any(os.path.exists(path) for path in marker_files):
-        return True
-
-    # LXC - check init process environment
-    try:
-        with open("/proc/1/environ", "r") as f:
-            if "container=lxc" in f.read():
-                return True
-    except (IOError, OSError):
-        pass
-
-    # Systemd-nspawn - check container type file
-    try:
-        with open("/run/systemd/container", "r") as f:
-            if f.read() == "systemd-nspawn\n":
-                return True
-    except (IOError, OSError):
-        pass
-
-    return False
 
 def is_ci_environment() -> bool:
     """Check if running in a CI environment"""
@@ -172,6 +150,12 @@ def safe_remove(path, is_dir=None):
     
     return False
 
+def _requirement_name(spec):
+    """Extract the bare package name from a requirements.txt line/spec."""
+    for sep in ("==", ">=", "<=", "~=", "!="):
+        spec = spec.split(sep)[0]
+    return spec
+
 def calculate_file_hash(filepath):
     """Calculate SHA256 hash of a file."""
     import hashlib
@@ -203,8 +187,7 @@ def cleanup_removed_packages():
                 for line in f:
                     line = line.strip()
                     if line and not line.startswith("#"):
-                        name = line.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0].split("!=")[0]
-                        result.add(name.strip().lower())
+                        result.add(_requirement_name(line).strip().lower())
         except Exception:
             pass
         return result
@@ -226,22 +209,6 @@ def cleanup_removed_packages():
                 pass
 
     safe_remove("requirements.old", is_dir=False)
-
-# v1.2.0 upgrade-path safeguard: if requirements.txt mentions any of these,
-# it's stale and the bootstrap will re-download a fresh one before installing.
-_OBSOLETE_REQUIREMENTS_MARKERS = ("ddddocr", "easyocr", "torch", "torchvision", "torchaudio")
-
-def has_obsolete_requirements():
-    """True if requirements.txt mentions packages from older bot versions."""
-    if not os.path.exists("requirements.txt"):
-        return False
-    try:
-        with open("requirements.txt", "r") as f:
-            content = f.read().lower()
-        return any(marker in content for marker in _OBSOLETE_REQUIREMENTS_MARKERS)
-    except Exception:
-        return False
-
 
 # Configuration for multiple update sources
 UPDATE_SOURCES = [
@@ -362,17 +329,6 @@ def download_requirements_from_release(beta_mode=False):
     except Exception:
         return False
 
-def _import_onnxruntime_quietly():
-    """Import onnxruntime while suppressing C++ GPU discovery warning."""
-    # Redirect fd 2 (C-level stderr) since ONNX writes there, not to sys.stderr
-    _fd, _null = sys.stderr.fileno(), os.open(os.devnull, os.O_WRONLY)
-    _bak = os.dup(_fd); os.dup2(_null, _fd); os.close(_null)
-    try:
-        import onnxruntime
-        return onnxruntime
-    finally:
-        os.dup2(_bak, _fd); os.close(_bak)
-
 def check_and_install_requirements():
     """Check each requirement and install missing ones."""
     if not os.path.exists("requirements.txt"):
@@ -386,8 +342,8 @@ def check_and_install_requirements():
     
     # Test each requirement
     for requirement in requirements:
-        package_name = requirement.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0].split("!=")[0]
-        
+        package_name = _requirement_name(requirement)
+
         try:
             if package_name == "discord.py":
                 import discord
@@ -403,8 +359,6 @@ def check_and_install_requirements():
                 import PIL
             elif package_name.lower() == "numpy":
                 import numpy
-            elif package_name.lower() == "onnxruntime":
-                _import_onnxruntime_quietly()
             else:
                 __import__(package_name)
 
@@ -415,7 +369,7 @@ def check_and_install_requirements():
         startup.phase_start("Installing missing packages")
 
         for package in missing_packages:
-            package_name = package.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0].split("!=")[0]
+            package_name = _requirement_name(package)
 
             try:
                 cmd = [sys.executable, "-m", "pip", "install", package, "--no-cache-dir"]
@@ -436,11 +390,6 @@ def setup_dependencies(beta_mode=False):
     """Main function to set up all dependencies."""
     startup.phase_start("Checking dependencies")
 
-    removed_obsolete = False
-    if has_obsolete_requirements():
-        removed_obsolete = True
-        safe_remove("requirements.txt", is_dir=False)
-
     if not os.path.exists("requirements.txt"):
         if not download_requirements_from_release(beta_mode=beta_mode):
             startup.phase_fail("Dependencies failed", details=["Could not download requirements.txt"], fix="Download the complete bot package from: https://github.com/whiteout-project/bot/releases")
@@ -453,8 +402,7 @@ def setup_dependencies(beta_mode=False):
     return True
 
 beta_mode = "--beta" in sys.argv
-if not setup_dependencies(beta_mode=beta_mode):
-    pass  # Warnings already shown by setup_dependencies
+setup_dependencies(beta_mode=beta_mode)  # Warnings shown internally on failure
 
 try:
     from colorama import Fore, Style, init
@@ -519,10 +467,7 @@ try:
     if original_create_default_https_context is None or \
        original_create_default_https_context is ssl.create_default_context:
         ssl._create_default_https_context = _create_ssl_context_with_certifi
-        
-        pass  # SSL context patch applied silently
-    else: # Assume if it's already patched, it's for a good reason
-        pass  # SSL context already modified, skip
+    # else: already patched elsewhere, leave it alone
 except ImportError:
     pass  # Certifi not found, SSL verification might fail
 except Exception:
@@ -542,12 +487,10 @@ if __name__ == "__main__":
             if _proxy_idx + 1 < len(sys.argv) and not sys.argv[_proxy_idx + 1].startswith("--")
             else "http://localhost:18080"
         )
-        import os as _os
-        _os.environ.setdefault("HTTP_PROXY",  _proxy_url)
-        _os.environ.setdefault("HTTPS_PROXY", _proxy_url)
-        _os.environ.setdefault("http_proxy",  _proxy_url)
-        _os.environ.setdefault("https_proxy", _proxy_url)
-    import requests
+        os.environ.setdefault("HTTP_PROXY",  _proxy_url)
+        os.environ.setdefault("HTTPS_PROXY", _proxy_url)
+        os.environ.setdefault("http_proxy",  _proxy_url)
+        os.environ.setdefault("https_proxy", _proxy_url)
 
     # Display startup header
     _version = "unknown"
@@ -579,29 +522,6 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    def restart_bot():
-        python = sys.executable
-        script_path = os.path.abspath(sys.argv[0])
-        # Filter out --no-venv and --repair from restart args to avoid loops
-        filtered_args = [arg for arg in sys.argv[1:] if arg not in ["--no-venv", "--repair"]]
-        args = [python, script_path] + filtered_args
-
-        if sys.platform == "win32":
-            # For Windows, provide direct venv command like initial setup
-            venv_path = "bot_venv"
-            venv_python_name = os.path.join(venv_path, "Scripts", "python.exe")
-            startup.venv_exists_instructions(venv_python_name, sys.platform)
-            sys.exit(0)
-        else:
-            # For non-Windows, try automatic restart
-            print("  Restarting bot...")
-            try:
-                subprocess.Popen(args)
-                os._exit(0)
-            except Exception as e:
-                print(f"Error restarting: {e}")
-                os.execl(python, python, script_path, *sys.argv[1:])
-            
     def install_packages(requirements_txt_path: str, debug: bool = False) -> bool:
         """Install packages from requirements.txt file using pip install -r."""
         full_command = [sys.executable, "-m", "pip", "install", "-r", requirements_txt_path, "--no-cache-dir"]
@@ -808,7 +728,7 @@ if __name__ == "__main__":
 
                         startup.phase_ok(f"Update completed (v{latest_tag} from {source_name})")
 
-                        restart_bot()
+                        restart_process()
                     else:
                         startup.phase_fail("Update failed", details=[f"HTTP {download_resp.status_code} from {source_name}"])
                         return
@@ -820,10 +740,8 @@ if __name__ == "__main__":
     import asyncio
     from datetime import datetime
             
-    # Handle update/repair logic
-    if "--repair" in sys.argv:
-        asyncio.run(check_and_update_files())
-    elif "--no-update" in sys.argv:
+    # Handle update/repair logic (--repair is detected inside check_and_update_files)
+    if "--no-update" in sys.argv:
         startup.phase_ok("Update check skipped")
     else:
         asyncio.run(check_and_update_files())
@@ -969,8 +887,6 @@ if __name__ == "__main__":
                 print("Invalid --save-captcha value. Must be 0-3. Defaulting to 0.")
                 bot.save_captcha = 0
 
-    init(autoreset=True)
-
     token_file = "bot_token.txt"
     if not os.path.exists(token_file):
         bot_token = input("Enter the bot token: ")
@@ -1083,20 +999,13 @@ if __name__ == "__main__":
         # Suppress all console output during cog loading to prevent
         # third-party libraries (RapidOCR, onnxruntime) from spamming.
         logging.disable(logging.INFO)
-        _real_stderr = sys.stderr
-        sys.stderr = open(os.devnull, 'w')
-        # Also suppress empty newlines leaking through stdout filter
-        _real_stdout = sys.stdout
-        sys.stdout = open(os.devnull, 'w')
-
-        for cog in cogs:
-            try:
-                await bot.load_extension(f"cogs.{cog}")
-            except Exception as e:
-                failed_cogs.append((cog, str(e)))
-
-        sys.stdout = _real_stdout
-        sys.stderr = _real_stderr
+        with open(os.devnull, 'w') as devnull, \
+                contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
+            for cog in cogs:
+                try:
+                    await bot.load_extension(f"cogs.{cog}")
+                except Exception as e:
+                    failed_cogs.append((cog, str(e)))
         logging.disable(logging.NOTSET)
 
         total = len(cogs)
@@ -1280,5 +1189,4 @@ if __name__ == "__main__":
         except KeyboardInterrupt:
             pass  # Already handled by signal handler
 
-    if __name__ == "__main__":
-        run_bot()
+    run_bot()


### PR DESCRIPTION
Cleans up main.py code so it's a bit leaner and prunes some old leftovers from previous versions that are not needed anymore.

- Collapses the two duplicate restart implementations (main.py's post-update restart and Bot Health's button restart) into one shared `cogs/bot_restart.py` (`is_container` + `restart_process`).
- Per-platform restart behavior: containers exit for the orchestrator, Linux/Mac `os.execl` in place, Windows stops with run instructions (no auto-restart, by design). Adds a visible "Restarting bot..." line mostly for CI.
- Removes the onnxruntime nightly quiet-import (now on stable)
- Moves the v1.2.0 obsolete-requirements cleanup responsibility to bot health's cleanup
- Cleaned up a redundant nested `__main__`, duplicate colorama init, no-op SSL scaffolding, redundant imports, and a few other minor tweaks and fixes
- Cleanup now also removes a stray `tests/` dir from non-git (production) installs.

Verified the bot still loads and all unit tests and upgrade tests pass.

Files: `main.py`, `cogs/bot_restart.py` (new), `cogs/bot_health.py`