### PR TITLE
External ocr engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ version
 backups
 captcha_images
 .vscode
+ocr_handler.py
 CLAUDE.md

--- a/cogs/bear_track.py
+++ b/cogs/bear_track.py
@@ -43,6 +43,33 @@ except ImportError:
 
 from . import onnx_lifecycle
 
+# External OCR engine support.  When --ext-ocr <url> is passed to main.py it
+# sets EXT_OCR_URL in the environment.  Both ocr_bytes() and
+# ocr_bytes_with_boxes() will POST to that service instead of loading models
+# locally.  The local RapidOCR stack is still imported as a fallback when the
+# env var is absent, so nothing breaks for self-hosters who don't use it.
+EXT_OCR_URL: str | None = os.environ.get("EXT_OCR_URL") or None
+# Optional shared secret, forwarded as X-OCR-Token when set. Must match the
+# handler's EXT_OCR_TOKEN. Unset = no auth header (trusted LAN).
+EXT_OCR_TOKEN: str | None = os.environ.get("EXT_OCR_TOKEN") or None
+# Lazily-created, reused aiohttp session for ext-OCR calls. A single bear/
+# attendance session issues many sequential OCR requests; reusing one session
+# keeps the TCP connection warm instead of reconnecting per image. Bound to the
+# bot's event loop, created on first use.
+_ext_ocr_session = None
+_EXT_OCR_HEADERS = {"X-OCR-Token": EXT_OCR_TOKEN} if EXT_OCR_TOKEN else None
+
+
+async def _get_ext_ocr_session():
+    import aiohttp
+    global _ext_ocr_session
+    if _ext_ocr_session is None or _ext_ocr_session.closed:
+        _ext_ocr_session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30),
+            headers=_EXT_OCR_HEADERS or {},
+        )
+    return _ext_ocr_session
+
 # RapidOCR setup. Engines are lazy-loaded per language via onnx_lifecycle and
 # unloaded ~2 min after the last bear session finalises.
 OCR_AVAILABLE = False
@@ -628,13 +655,58 @@ async def _maybe_breathe():
         await asyncio.sleep(_LOW_MEM_OCR_PAUSE)
 
 
+async def _ext_ocr_bytes(image_bytes: bytes, lang: str) -> str:
+    """Send image bytes to the external OCR service and return the text.
+    Returns "" on any network or protocol error so callers degrade gracefully."""
+    import base64
+    payload = {"image": base64.b64encode(image_bytes).decode(), "lang": lang}
+    try:
+        sess = await _get_ext_ocr_session()
+        async with sess.post(EXT_OCR_URL, json=payload) as resp:
+            if resp.status != 200:
+                logger.warning(f"Ext OCR service returned HTTP {resp.status}")
+                return ""
+            data = await resp.json()
+            return data.get("text", "")
+    except Exception as e:
+        logger.warning(f"Ext OCR request failed: {e}")
+        return ""
+
+
+async def _ext_ocr_bytes_with_boxes(image_bytes: bytes, lang: str) -> list:
+    """Send image bytes to the external OCR service and return [(text, box), ...].
+    Returns [] on any network or protocol error."""
+    import base64
+    payload = {"image": base64.b64encode(image_bytes).decode(), "lang": lang, "boxes": True}
+    try:
+        sess = await _get_ext_ocr_session()
+        async with sess.post(EXT_OCR_URL, json=payload) as resp:
+            if resp.status != 200:
+                logger.warning(f"Ext OCR service (boxes) returned HTTP {resp.status}")
+                return []
+            data = await resp.json()
+            return [(item["text"], item["box"]) for item in data.get("results", [])]
+    except Exception as e:
+        logger.warning(f"Ext OCR (boxes) request failed: {e}")
+        return []
+
+
 async def ocr_bytes(image_bytes: bytes, lang: str = DEFAULT_OCR_LANG, *, session=None) -> str:
     """OCR `image_bytes` → space-joined text, or "" on failure.
 
-    If `session` is given, the engine is acquired via the session (warm reuse
-    across multiple OCR calls in one bear session). Otherwise this falls back
-    to a one-shot acquire/release covered by the lifecycle grace period."""
-    if not OCR_AVAILABLE or not image_bytes:
+    When EXT_OCR_URL is set (via --ext-ocr flag), the image is forwarded to
+    the external OCR handler instead of loading models locally.  The `session`
+    parameter is ignored in that path (no warm-engine reuse needed; the remote
+    service manages its own lifecycle).
+
+    If `session` is given (local mode), the engine is acquired via the session
+    (warm reuse across multiple OCR calls in one bear session). Otherwise this
+    falls back to a one-shot acquire/release covered by the lifecycle grace period."""
+    if not image_bytes:
+        return ""
+    if EXT_OCR_URL:
+        return await _ext_ocr_bytes(image_bytes, lang)
+    if not OCR_AVAILABLE:
         return ""
     model = get_ocr_model(lang)
     if model is None:
@@ -682,8 +754,13 @@ def _ocr_image_with_engine_boxed(image_bytes, engine) -> list:
 
 async def ocr_bytes_with_boxes(image_bytes: bytes, lang: str = DEFAULT_OCR_LANG,
                                *, session=None) -> list:
-    """OCR returning [(text, box), ...]. Box is 4 corner coords. Empty list on failure."""
-    if not OCR_AVAILABLE or not image_bytes:
+    """OCR returning [(text, box), ...]. Box is 4 corner coords. Empty list on failure.
+    When EXT_OCR_URL is set, forwards to the external handler with boxes=True."""
+    if not image_bytes:
+        return []
+    if EXT_OCR_URL:
+        return await _ext_ocr_bytes_with_boxes(image_bytes, lang)
+    if not OCR_AVAILABLE:
         return []
     model = get_ocr_model(lang)
     if model is None:

--- a/main.py
+++ b/main.py
@@ -647,6 +647,23 @@ if __name__ == "__main__":
         os.environ.setdefault("http_proxy",  _proxy_url)
         os.environ.setdefault("https_proxy", _proxy_url)
 
+    # ── External OCR engine support (--ext-ocr flag) ───────────────────────────
+    # Pass --ext-ocr <url> to offload all OCR work to an external handler.
+    # Example: python main.py --ext-ocr http://192.168.1.20:18090
+    # If --ext-ocr is passed without a URL, defaults to http://localhost:18090.
+    # The handler (ocr_handler.py) must be running separately; it receives the
+    # image via HTTP POST and returns the recognised text.  When this flag is
+    # active the bot loads no ONNX models and has no RapidOCR RAM overhead.
+    _ext_ocr_url = None
+    if "--ext-ocr" in sys.argv:
+        _ext_ocr_idx = sys.argv.index("--ext-ocr")
+        _ext_ocr_url = (
+            sys.argv[_ext_ocr_idx + 1]
+            if _ext_ocr_idx + 1 < len(sys.argv) and not sys.argv[_ext_ocr_idx + 1].startswith("--")
+            else "http://localhost:18090"
+        )
+        os.environ["EXT_OCR_URL"] = _ext_ocr_url
+
     # Display startup header
     _version = "unknown"
     if os.path.exists("version"):
@@ -659,9 +676,12 @@ if __name__ == "__main__":
     if '--repair' in sys.argv: _flags.append('--repair')
     if '--break-system-packages' in sys.argv: _flags.append('--break-system-packages')
     if _proxy_url: _flags.append('--proxy')
+    if _ext_ocr_url: _flags.append('--ext-ocr')
     startup.header(_version, f"{sys.version_info.major}.{sys.version_info.minor}", _flags or None)
     if _proxy_url:
         startup.info(f"Routing player traffic through proxy: {_proxy_url}")
+    if _ext_ocr_url:
+        startup.info(f"External OCR engine: {_ext_ocr_url}")
 
     # Check for mutually exclusive flags
     mutually_exclusive_flags = ["--autoupdate", "--no-update", "--repair"]

--- a/ocr_handler.py
+++ b/ocr_handler.py
@@ -6,13 +6,27 @@ Runs as a standalone HTTP service that receives image bytes, runs RapidOCR,
 and returns the recognised text. The bot offloads all model RAM to this
 process by starting with --ext-ocr <url>.
 
+Multiple bots from multiple users on the same network can share one handler.
+Concurrent requests are serialised per language via a semaphore sized to
+(cpu_count / OCR_NUM_THREADS) so CPU thrashing is avoided under load.
+
 Usage:
     python ocr_handler.py                       # listens on 0.0.0.0:18090
     python ocr_handler.py --port 18090
     python ocr_handler.py --host 127.0.0.1 --port 18090
 
 Install dependencies (once):
-    pip install rapidocr pillow numpy aiohttp aiohttp-web
+    pip install rapidocr pillow numpy aiohttp
+
+Environment variables:
+    EXT_OCR_TOKEN     Shared secret. When set, every POST /ocr must carry a
+                      matching X-OCR-Token header or receive 401. Leave unset
+                      on a trusted LAN. Never pass as a CLI flag (leaks in ps).
+    OCR_NUM_THREADS   onnxruntime intra/inter thread count per engine (default 2).
+    MAX_OCR_DIM       Longest image edge after resize (default 1600).
+    OCR_MAX_QUEUE     Max requests waiting for inference per language before the
+                      handler returns 429. Prevents memory growth under spikes
+                      (default 16).
 
 API:
     POST /ocr
@@ -23,14 +37,17 @@ API:
         "boxes": false          # optional — set true for box coordinates
     }
 
-    200 OK (text mode):
-    { "text": "recognised text here" }
+    200 OK (text mode):    { "text": "recognised text here" }
+    200 OK (boxes mode):   { "results": [ {"text": "foo", "box": [[x,y],...] }, ... ] }
+    400  malformed request or undecodable image
+    401  missing or wrong X-OCR-Token
+    429  inference queue full (shed load)
+    500  OCR runtime error
+    503  RapidOCR failed to import on this host
 
-    200 OK (boxes mode):
-    { "results": [ {"text": "foo", "box": [[x1,y1],[x2,y2],[x3,y3],[x4,y4]]}, ... ] }
-
-    503 if OCR is not available (import failed).
-    400 if the request is malformed or the image cannot be decoded.
+    GET /health
+    { "ok": true, "engines_loaded": ["en"], "num_threads": 2, "max_dim": 1600,
+      "max_queue": 16, "queue_depth": { "en": 0 } }
 """
 from __future__ import annotations
 
@@ -47,6 +64,31 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 logger = logging.getLogger("ocr_handler")
+
+# ── Config from environment ──────────────────────────────────────────────────
+
+# Optional shared-secret auth. When set, every POST /ocr must carry a matching
+# X-OCR-Token header or receive 401. Leave unset on a trusted LAN.
+AUTH_TOKEN = os.environ.get("EXT_OCR_TOKEN") or None
+
+# onnxruntime thread count per engine. 2 is a good balance on a dedicated host;
+# lower to 1 on a constrained box, raise if you have cores to spare.
+OCR_NUM_THREADS = int(os.environ.get("OCR_NUM_THREADS", "2"))
+
+# Longest edge in pixels after thumbnail. Above ~1800 px onnxruntime hits
+# bad-allocation errors on the second/third image in a session.
+MAX_OCR_DIM = int(os.environ.get("MAX_OCR_DIM", "1600"))
+
+# Maximum number of requests queued waiting for an inference slot per language.
+# Requests that arrive when the queue is full receive 429 immediately rather
+# than piling up in the thread pool silently. 16 is generous for a handful of
+# bots; lower it if RAM is tight.
+OCR_MAX_QUEUE = int(os.environ.get("OCR_MAX_QUEUE", "16"))
+
+# Derived: how many inference jobs can run concurrently.
+# cpu_count() / OCR_NUM_THREADS — at least 1, at most OCR_MAX_QUEUE.
+_cpu = os.cpu_count() or 1
+OCR_CONCURRENCY = max(1, _cpu // OCR_NUM_THREADS)
 
 # ── RapidOCR setup ──────────────────────────────────────────────────────────
 
@@ -69,20 +111,27 @@ except Exception as exc:
     OCR_AVAILABLE = False
     logger.error(f"RapidOCR unavailable: {exc}")
 
-# Optional shared-secret auth. If EXT_OCR_TOKEN is set in this process's env,
-# requests must carry a matching `X-OCR-Token` header (or be rejected 401).
-# Leave it unset for a trusted LAN; set it when the handler is reachable by
-# other tenants on shared infrastructure.
-AUTH_TOKEN = os.environ.get("EXT_OCR_TOKEN") or None
+# ── Engine cache + per-language semaphores ───────────────────────────────────
 
-# Thread count: 2 is a good balance for a dedicated OCR host.
-# Raise it if you have cores to spare; lower to 1 for very constrained boxes.
-OCR_NUM_THREADS = int(os.environ.get("OCR_NUM_THREADS", "2"))
-MAX_OCR_DIM = int(os.environ.get("MAX_OCR_DIM", "1600"))
-
-# Per-language engine cache (one engine per lang, loaded on demand)
+# One RapidOCR engine per language, loaded on first use and kept for the
+# lifetime of the process (dedicated host; no eviction needed).
 _ENGINES: dict[str, "RapidOCR"] = {}
 _ENGINE_LOCK = asyncio.Lock()
+
+# Per-language semaphore: caps concurrent inference jobs to OCR_CONCURRENCY.
+# A separate semaphore per language means English requests don't block Arabic
+# ones when each language has a different engine loaded.
+_LANG_SEMAPHORES: dict[str, asyncio.Semaphore] = {}
+# Tracks how many requests are currently waiting or running per language,
+# so handle_ocr can reject early (429) when the queue is full.
+_LANG_QUEUE_DEPTH: dict[str, int] = {}
+
+
+def _get_lang_semaphore(lang: str) -> asyncio.Semaphore:
+    if lang not in _LANG_SEMAPHORES:
+        _LANG_SEMAPHORES[lang] = asyncio.Semaphore(OCR_CONCURRENCY)
+        _LANG_QUEUE_DEPTH[lang] = 0
+    return _LANG_SEMAPHORES[lang]
 
 
 def _make_engine(lang: str) -> "RapidOCR":
@@ -103,9 +152,10 @@ async def _get_engine(lang: str) -> "RapidOCR":
             logger.info(f"Engine for lang={lang!r} ready.")
         return _ENGINES[lang]
 
+# ── Image processing ─────────────────────────────────────────────────────────
 
 def _run_ocr(image_bytes: bytes, engine: "RapidOCR") -> "object":
-    """Synchronous OCR call — runs in a thread pool."""
+    """Synchronous OCR call — runs in the thread pool via to_thread."""
     with Image.open(io.BytesIO(image_bytes)) as src:
         image = src.convert("RGB")
     if max(image.size) > MAX_OCR_DIM:
@@ -126,16 +176,15 @@ def _extract_text(result) -> str:
 
 
 def _to_list(box):
-    """RapidOCR boxes are numpy arrays (float32) — not JSON serializable.
-    Coerce to nested Python lists. Already-list input passes through."""
+    """RapidOCR boxes are numpy float32 ndarrays — not JSON serializable.
+    Coerce to plain nested Python lists. Already-list input passes through."""
     if hasattr(box, "tolist"):
         return box.tolist()
     return [[float(p[0]), float(p[1])] for p in box]
 
 
 def _extract_boxes(result) -> list:
-    """Extract [{"text":..., "box":...}, ...] from a RapidOCR result, with
-    boxes coerced to plain nested lists so json.dumps can serialize them."""
+    """Extract [{"text":..., "box":[[x,y],...]},...] from a RapidOCR result."""
     if not result:
         return []
     if hasattr(result, "txts") and hasattr(result, "boxes") and result.txts:
@@ -149,8 +198,7 @@ def _extract_boxes(result) -> list:
         return out
     return []
 
-
-# ── aiohttp web handler ──────────────────────────────────────────────────────
+# ── aiohttp web handlers ─────────────────────────────────────────────────────
 
 try:
     from aiohttp import web
@@ -165,15 +213,15 @@ VALID_LANGS = {
 
 
 async def handle_ocr(request: "web.Request") -> "web.Response":
+    # ── Auth ──────────────────────────────────────────────────────────────────
     if AUTH_TOKEN is not None and request.headers.get("X-OCR-Token") != AUTH_TOKEN:
         return web.json_response({"error": "unauthorized"}, status=401)
 
     if not OCR_AVAILABLE:
         return web.json_response(
-            {"error": "RapidOCR not available on this host"},
-            status=503,
-        )
+            {"error": "RapidOCR not available on this host"}, status=503)
 
+    # ── Parse request ─────────────────────────────────────────────────────────
     try:
         body = await request.json()
     except Exception:
@@ -195,19 +243,35 @@ async def handle_ocr(request: "web.Request") -> "web.Response":
         return web.json_response({"error": "image is not valid base64"}, status=400)
 
     if not image_bytes:
-        if want_boxes:
-            return web.json_response({"results": []})
-        return web.json_response({"text": ""})
+        return web.json_response({"results": []} if want_boxes else {"text": ""})
 
+    # ── Queue management ──────────────────────────────────────────────────────
+    sem = _get_lang_semaphore(lang)
+
+    # Reject immediately if the queue for this language is already full.
+    # waiting = total slots - available slots = what's currently in flight or waiting.
+    waiting = OCR_CONCURRENCY - sem._value + _LANG_QUEUE_DEPTH.get(lang, 0)
+    if waiting >= OCR_MAX_QUEUE:
+        logger.warning(f"Queue full for lang={lang!r} ({waiting} waiting) — shedding request")
+        return web.json_response(
+            {"error": f"OCR queue full for lang '{lang}', try again shortly"}, status=429)
+
+    _LANG_QUEUE_DEPTH[lang] = _LANG_QUEUE_DEPTH.get(lang, 0) + 1
+
+    # ── Inference ─────────────────────────────────────────────────────────────
     try:
         engine = await _get_engine(lang)
-        result = await asyncio.to_thread(_run_ocr, image_bytes, engine)
+        async with sem:
+            result = await asyncio.to_thread(_run_ocr, image_bytes, engine)
     except Image.DecompressionBombError:
         return web.json_response({"error": "image too large"}, status=400)
     except Exception as exc:
         logger.exception("OCR failed")
         return web.json_response({"error": f"OCR error: {exc}"}, status=500)
+    finally:
+        _LANG_QUEUE_DEPTH[lang] = max(0, _LANG_QUEUE_DEPTH.get(lang, 1) - 1)
 
+    # ── Respond ───────────────────────────────────────────────────────────────
     if want_boxes:
         return web.json_response({"results": _extract_boxes(result)})
     return web.json_response({"text": _extract_text(result)})
@@ -218,7 +282,10 @@ async def handle_health(request: "web.Request") -> "web.Response":
         "ok": OCR_AVAILABLE,
         "engines_loaded": list(_ENGINES.keys()),
         "num_threads": OCR_NUM_THREADS,
+        "concurrency": OCR_CONCURRENCY,
         "max_dim": MAX_OCR_DIM,
+        "max_queue": OCR_MAX_QUEUE,
+        "queue_depth": dict(_LANG_QUEUE_DEPTH),
     })
 
 
@@ -227,7 +294,6 @@ def build_app() -> "web.Application":
     app.router.add_post("/ocr", handle_ocr)
     app.router.add_get("/health", handle_health)
     return app
-
 
 # ── Entry point ──────────────────────────────────────────────────────────────
 
@@ -241,7 +307,10 @@ def main():
     logger.info(f"Starting OCR handler on {args.host}:{args.port}")
     logger.info(f"  OCR available : {OCR_AVAILABLE}")
     logger.info(f"  Threads/engine: {OCR_NUM_THREADS}")
+    logger.info(f"  Concurrency   : {OCR_CONCURRENCY} (cpu={_cpu})")
     logger.info(f"  Max image dim : {MAX_OCR_DIM}px")
+    logger.info(f"  Max queue/lang: {OCR_MAX_QUEUE}")
+    logger.info(f"  Auth token    : {'set' if AUTH_TOKEN else 'not set (open)'}")
     web.run_app(app, host=args.host, port=args.port, print=None)
 
 

--- a/ocr_handler.py
+++ b/ocr_handler.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+External OCR handler for the WOS/KS bot.
+
+Runs as a standalone HTTP service that receives image bytes, runs RapidOCR,
+and returns the recognised text. The bot offloads all model RAM to this
+process by starting with --ext-ocr <url>.
+
+Usage:
+    python ocr_handler.py                       # listens on 0.0.0.0:18090
+    python ocr_handler.py --port 18090
+    python ocr_handler.py --host 127.0.0.1 --port 18090
+
+Install dependencies (once):
+    pip install rapidocr pillow numpy aiohttp aiohttp-web
+
+API:
+    POST /ocr
+    Content-Type: application/json
+    {
+        "image": "<base64-encoded image bytes>",
+        "lang":  "en",          # optional, defaults to "en"
+        "boxes": false          # optional — set true for box coordinates
+    }
+
+    200 OK (text mode):
+    { "text": "recognised text here" }
+
+    200 OK (boxes mode):
+    { "results": [ {"text": "foo", "box": [[x1,y1],[x2,y2],[x3,y3],[x4,y4]]}, ... ] }
+
+    503 if OCR is not available (import failed).
+    400 if the request is malformed or the image cannot be decoded.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import io
+import logging
+import os
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("ocr_handler")
+
+# ── RapidOCR setup ──────────────────────────────────────────────────────────
+
+try:
+    import numpy as np
+    from PIL import Image
+    # Cap decoded image size to defend against decompression bombs: a tiny
+    # crafted PNG can expand to billions of pixels and OOM the host. Game
+    # screenshots are well under 10 MP; 40 MP leaves generous headroom.
+    Image.MAX_IMAGE_PIXELS = 40_000_000
+    from rapidocr import RapidOCR, LangRec
+    try:
+        from rapidocr.utils.download_file import DownloadFile
+        DownloadFile.check_is_atty = staticmethod(lambda: False)
+    except Exception:
+        pass
+    OCR_AVAILABLE = True
+    logger.info("RapidOCR loaded successfully — handler ready.")
+except Exception as exc:
+    OCR_AVAILABLE = False
+    logger.error(f"RapidOCR unavailable: {exc}")
+
+# Optional shared-secret auth. If EXT_OCR_TOKEN is set in this process's env,
+# requests must carry a matching `X-OCR-Token` header (or be rejected 401).
+# Leave it unset for a trusted LAN; set it when the handler is reachable by
+# other tenants on shared infrastructure.
+AUTH_TOKEN = os.environ.get("EXT_OCR_TOKEN") or None
+
+# Thread count: 2 is a good balance for a dedicated OCR host.
+# Raise it if you have cores to spare; lower to 1 for very constrained boxes.
+OCR_NUM_THREADS = int(os.environ.get("OCR_NUM_THREADS", "2"))
+MAX_OCR_DIM = int(os.environ.get("MAX_OCR_DIM", "1600"))
+
+# Per-language engine cache (one engine per lang, loaded on demand)
+_ENGINES: dict[str, "RapidOCR"] = {}
+_ENGINE_LOCK = asyncio.Lock()
+
+
+def _make_engine(lang: str) -> "RapidOCR":
+    return RapidOCR(params={
+        "Rec.lang_type": LangRec(lang),
+        "EngineConfig.onnxruntime.intra_op_num_threads": OCR_NUM_THREADS,
+        "EngineConfig.onnxruntime.inter_op_num_threads": OCR_NUM_THREADS,
+    })
+
+
+async def _get_engine(lang: str) -> "RapidOCR":
+    """Return a cached engine for `lang`, creating it if needed (thread-safe)."""
+    async with _ENGINE_LOCK:
+        if lang not in _ENGINES:
+            logger.info(f"Loading OCR engine for lang={lang!r} …")
+            engine = await asyncio.to_thread(_make_engine, lang)
+            _ENGINES[lang] = engine
+            logger.info(f"Engine for lang={lang!r} ready.")
+        return _ENGINES[lang]
+
+
+def _run_ocr(image_bytes: bytes, engine: "RapidOCR") -> "object":
+    """Synchronous OCR call — runs in a thread pool."""
+    with Image.open(io.BytesIO(image_bytes)) as src:
+        image = src.convert("RGB")
+    if max(image.size) > MAX_OCR_DIM:
+        image.thumbnail((MAX_OCR_DIM, MAX_OCR_DIM), Image.LANCZOS)
+    return engine(np.array(image))
+
+
+def _extract_text(result) -> str:
+    if not result:
+        return ""
+    if hasattr(result, "txts") and result.txts:
+        return " ".join(str(t) for t in result.txts)
+    if hasattr(result, "__iter__"):
+        texts = [str(item[1]) for item in result
+                 if isinstance(item, (list, tuple)) and len(item) >= 2]
+        return " ".join(texts) if texts else str(result)
+    return str(result)
+
+
+def _to_list(box):
+    """RapidOCR boxes are numpy arrays (float32) — not JSON serializable.
+    Coerce to nested Python lists. Already-list input passes through."""
+    if hasattr(box, "tolist"):
+        return box.tolist()
+    return [[float(p[0]), float(p[1])] for p in box]
+
+
+def _extract_boxes(result) -> list:
+    """Extract [{"text":..., "box":...}, ...] from a RapidOCR result, with
+    boxes coerced to plain nested lists so json.dumps can serialize them."""
+    if not result:
+        return []
+    if hasattr(result, "txts") and hasattr(result, "boxes") and result.txts:
+        return [{"text": str(t), "box": _to_list(b)}
+                for t, b in zip(result.txts, result.boxes)]
+    if hasattr(result, "__iter__"):
+        out = []
+        for item in result:
+            if isinstance(item, (list, tuple)) and len(item) >= 2:
+                out.append({"text": str(item[1]), "box": _to_list(item[0])})
+        return out
+    return []
+
+
+# ── aiohttp web handler ──────────────────────────────────────────────────────
+
+try:
+    from aiohttp import web
+except ImportError:
+    logger.error("aiohttp is not installed. Run: pip install aiohttp")
+    sys.exit(1)
+
+VALID_LANGS = {
+    "en", "ch", "japan", "korean", "chinese_cht",
+    "latin", "arabic", "cyrillic", "devanagari",
+}
+
+
+async def handle_ocr(request: "web.Request") -> "web.Response":
+    if AUTH_TOKEN is not None and request.headers.get("X-OCR-Token") != AUTH_TOKEN:
+        return web.json_response({"error": "unauthorized"}, status=401)
+
+    if not OCR_AVAILABLE:
+        return web.json_response(
+            {"error": "RapidOCR not available on this host"},
+            status=503,
+        )
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "invalid JSON body"}, status=400)
+
+    raw_image = body.get("image")
+    if not raw_image:
+        return web.json_response({"error": "missing 'image' field"}, status=400)
+
+    lang = str(body.get("lang", "en"))
+    if lang not in VALID_LANGS:
+        lang = "en"
+
+    want_boxes = bool(body.get("boxes", False))
+
+    try:
+        image_bytes = base64.b64decode(raw_image)
+    except Exception:
+        return web.json_response({"error": "image is not valid base64"}, status=400)
+
+    if not image_bytes:
+        if want_boxes:
+            return web.json_response({"results": []})
+        return web.json_response({"text": ""})
+
+    try:
+        engine = await _get_engine(lang)
+        result = await asyncio.to_thread(_run_ocr, image_bytes, engine)
+    except Image.DecompressionBombError:
+        return web.json_response({"error": "image too large"}, status=400)
+    except Exception as exc:
+        logger.exception("OCR failed")
+        return web.json_response({"error": f"OCR error: {exc}"}, status=500)
+
+    if want_boxes:
+        return web.json_response({"results": _extract_boxes(result)})
+    return web.json_response({"text": _extract_text(result)})
+
+
+async def handle_health(request: "web.Request") -> "web.Response":
+    return web.json_response({
+        "ok": OCR_AVAILABLE,
+        "engines_loaded": list(_ENGINES.keys()),
+        "num_threads": OCR_NUM_THREADS,
+        "max_dim": MAX_OCR_DIM,
+    })
+
+
+def build_app() -> "web.Application":
+    app = web.Application(client_max_size=20 * 1024 * 1024)  # 20 MB max image
+    app.router.add_post("/ocr", handle_ocr)
+    app.router.add_get("/health", handle_health)
+    return app
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="External OCR handler for the WOS/KS bot")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=18090, help="Bind port (default: 18090)")
+    args = parser.parse_args()
+
+    app = build_app()
+    logger.info(f"Starting OCR handler on {args.host}:{args.port}")
+    logger.info(f"  OCR available : {OCR_AVAILABLE}")
+    logger.info(f"  Threads/engine: {OCR_NUM_THREADS}")
+    logger.info(f"  Max image dim : {MAX_OCR_DIM}px")
+    web.run_app(app, host=args.host, port=args.port, print=None)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
fix(ocr_handler): handle concurrent multi-bot requests safely

Adds per-language request queuing with backpressure to prevent CPU
thrashing and silent thread pool pile-up under concurrent load from
multiple bots on the same network.

---

## ocr_handler.py

### New: per-language inference semaphore

  _LANG_SEMAPHORES — dict[str, asyncio.Semaphore], one entry per language,
  created lazily on first request for that language.

  Semaphore width = max(1, cpu_count() // OCR_NUM_THREADS), derived at
  startup and logged. On a 4-core host with OCR_NUM_THREADS=2 this allows
  2 concurrent inference jobs. On a 2-core host it allows 1.

  Semaphores are per-language rather than global: an English queue does
  not block a Korean queue. Both can run concurrently up to the derived
  concurrency limit independently.

### New: queue depth tracking + 429 shedding

  _LANG_QUEUE_DEPTH — dict[str, int], incremented on entry to handle_ocr
  and decremented in a finally block after inference completes or errors.

  Before acquiring the semaphore, handle_ocr computes:
    waiting = (OCR_CONCURRENCY - sem._value) + _LANG_QUEUE_DEPTH[lang]
  If waiting >= OCR_MAX_QUEUE the request is rejected immediately with
  HTTP 429 and a descriptive error message, rather than queuing in the
  thread pool where it would consume memory and eventually timeout.

  OCR_MAX_QUEUE env var (default 16). Generous for a handful of bots;
  lower it on RAM-constrained hosts.

  The bot side (_ext_ocr_bytes / _ext_ocr_bytes_with_boxes) already
  handles non-200 responses by logging a warning and returning "" / [],
  so shed requests degrade to the existing "couldn't identify screenshot"
  user message without raising.

### New: OCR_CONCURRENCY config value

  Derived constant: max(1, cpu_count() // OCR_NUM_THREADS).
  Not directly env-configurable — the two constituent levers
  (OCR_NUM_THREADS, cpu_count) already give full control.

### Modified: handle_ocr

  - _get_lang_semaphore(lang) called to ensure semaphore and queue counter
    exist for the request's language before the queue check.
  - Queue depth check (429) inserted between request validation and engine
    acquisition, so malformed/unauthorized requests are still rejected
    before touching the queue.
  - _LANG_QUEUE_DEPTH[lang] incremented after the 429 check, decremented
    in finally so it is always released on error, timeout, or success.
  - Semaphore acquired with `async with sem` wrapping only the
    to_thread(_run_ocr) call, not engine loading, so a slow first-load
    does not consume an inference slot while waiting for the model.

### Modified: handle_health

  Added fields to the response:
    "concurrency"  — OCR_CONCURRENCY value in effect
    "max_queue"    — OCR_MAX_QUEUE value in effect
    "queue_depth"  — dict of current per-language queue depth snapshot

### Modified: main() startup log

  Added log lines for:
    Concurrency   : <N> (cpu=<M>)
    Max queue/lang: <N>
    Auth token    : set | not set (open)