### PR TITLE
Feat/power history

### DIFF
--- a/cogs/alliance_history.py
+++ b/cogs/alliance_history.py
@@ -10,8 +10,20 @@ from .alliance_member_operations import AllianceSelectView
 from .permission_handler import PermissionManager
 from .pimp_my_bot import theme
 from .bot_level_mapping import LEVEL_MAPPING
+from . import power_changes
 
 logger = logging.getLogger('alliance')
+
+
+def _fmt_power(n) -> str:
+    if n is None:
+        return "N/A"
+    n = int(n)
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    return f"{n:,}"
 
 
 async def _open_post_to_channel_picker(interaction: discord.Interaction, embed: discord.Embed):
@@ -54,7 +66,7 @@ class _SingleHistoryResultView(discord.ui.View):
         super().__init__(timeout=7200)
         self.cog = cog
         self.alliance_id = alliance_id
-        self.history_type = history_type  # "furnace" or "nickname"
+        self.history_type = history_type  # "furnace", "nickname", "power", or "combat_power"
         self.embed = embed
 
     @discord.ui.button(label="Back", emoji=f"{theme.backIcon}",
@@ -67,8 +79,16 @@ class _SingleHistoryResultView(discord.ui.View):
             return
         if self.history_type == "furnace":
             await self.cog.show_member_list_furnace(interaction, self.alliance_id)
-        else:
+        elif self.history_type == "nickname":
             await self.cog.show_member_list_nickname(interaction, self.alliance_id)
+        elif self.history_type == "power":
+            await self.cog.show_member_list_power(interaction, self.alliance_id)
+        elif self.history_type == "combat_power":
+            await self.cog.show_member_list_combat_power(interaction, self.alliance_id)
+        else:
+            await interaction.response.send_message(
+                f"{theme.deniedIcon} Unknown history type.", ephemeral=True
+            )
 
     @discord.ui.button(label="Post to Channel", emoji=f"{theme.announceIcon}",
                        style=discord.ButtonStyle.primary, row=0)
@@ -403,6 +423,8 @@ class AllianceHistory(commands.Cog):
                     f"{theme.upperDivider}\n"
                     f"{theme.stoveIcon} **Furnace Changes** — track FC level changes over time\n"
                     f"{theme.editListIcon} **Nickname Changes** — see when members renamed\n"
+                    f"{theme.upIcon} **Power Changes** - track power increase/decrease over time\n"
+                    f"{theme.chartIcon} **Combat Power Changes** - track combat power over time\n"
                     f"{theme.lowerDivider}"
                 ),
                 color=theme.emColor1,
@@ -469,6 +491,115 @@ class AllianceHistory(commands.Cog):
                 f"{theme.deniedIcon} An error occurred while displaying the member list.",
                 ephemeral=True
             )
+
+    async def show_power_history(self, interaction: discord.Interaction, fid: int,
+                                metric: str = "power"):
+        label = "Combat Power" if metric == "combat_power" else "Power"
+        col = "combat_power" if metric == "combat_power" else "power"
+        try:
+            changes = power_changes.history(fid, metric)
+            if not changes:
+                await interaction.followup.send(
+                    f"No {label.lower()} changes found for this player.",
+                    ephemeral=True,
+                )
+                return
+
+            with sqlite3.connect('db/users.sqlite') as users_db:
+                info = users_db.execute(
+                    f"SELECT nickname, {col}, alliance FROM users WHERE fid = ?",
+                    (fid,),
+                ).fetchone()
+            nickname = info[0] if info else "Unknown"
+            current = info[1] if info else None
+            alliance_id = info[2] if info else None
+
+            embed = discord.Embed(
+                title=f"{theme.chartIcon} {label} History",
+                description=(
+                    f"**Player:** `{nickname}`\n"
+                    f"**ID:** `{fid}`\n"
+                    f"**Current {label}:** `{_fmt_power(current)}`\n"
+                    f"{theme.upperDivider}\n"
+                ),
+                color=theme.emColor1,
+            )
+            for ch in changes:
+                badge = power_changes.format_delta(ch["pct"])
+                embed.add_field(
+                    name=f"Change at {ch['change_date'][:10]}",
+                    value=f"`{_fmt_power(ch['old'])}` {theme.forwardIcon} "
+                          f"`{_fmt_power(ch['new'])}`  {badge}",
+                    inline=False,
+                )
+            await interaction.followup.send(
+                embed=embed,
+                view=_SingleHistoryResultView(self, alliance_id, metric, embed),
+                ephemeral=True,
+            )
+        except Exception as e:
+            logger.error(f"Error in show_power_history ({metric}): {e}")
+            print(f"Error in show_power_history ({metric}): {e}")
+            await interaction.followup.send(
+                f"{theme.deniedIcon} An error occurred while displaying the {label.lower()} history.",
+                ephemeral=True,
+            )
+
+    async def show_member_list_power(self, interaction: discord.Interaction, alliance_id: int):
+        await self._show_member_list_power(interaction, alliance_id, "power")
+
+    async def show_member_list_combat_power(self, interaction: discord.Interaction, alliance_id: int):
+        await self._show_member_list_power(interaction, alliance_id, "combat_power")
+
+    async def _show_member_list_power(self, interaction: discord.Interaction,
+                                      alliance_id: int, metric: str):
+        label = "Combat Power" if metric == "combat_power" else "Power"
+        col = "combat_power" if metric == "combat_power" else "power"
+        icon = theme.chartIcon
+        try:
+            with sqlite3.connect('db/users.sqlite') as users_db:
+                members = users_db.execute(
+                    f"SELECT fid, nickname, {col} FROM users "
+                    f"WHERE alliance = ? ORDER BY {col} DESC, nickname",
+                    (alliance_id,),
+                ).fetchall()
+
+            if not members:
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} No members found in this alliance.",
+                    ephemeral=True,
+                )
+                return
+
+            with sqlite3.connect('db/alliance.sqlite') as alliance_db:
+                row = alliance_db.execute(
+                    "SELECT name FROM alliance_list WHERE alliance_id = ?",
+                    (alliance_id,),
+                ).fetchone()
+            alliance_name = row[0] if row else f"Alliance {alliance_id}"
+
+            view = MemberListViewPower(self, members, alliance_name, alliance_id, metric)
+            embed = discord.Embed(
+                title=f"{icon} {alliance_name} - Member List",
+                description=(
+                    f"Select a member to view {label.lower()} history:\n"
+                    f"{theme.upperDivider}\n"
+                    f"Total Members: {len(members)}\n"
+                    f"Current Page: 1/{view.total_pages}\n"
+                    f"{theme.lowerDivider}"
+                ),
+                color=theme.emColor1,
+            )
+            await interaction.response.edit_message(embed=embed, view=view)
+
+        except Exception as e:
+            logger.error(f"Error in _show_member_list_power ({metric}): {e}")
+            print(f"Error in _show_member_list_power ({metric}): {e}")
+            if not interaction.response.is_done():
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} An error occurred while showing the member list.",
+                    ephemeral=True,
+                )
 
     async def show_recent_changes(self, interaction: discord.Interaction, alliance_name: str, match: re.Match):
         time_multipliers = {"h": 1, "d": 24, "mo": 24 * 30}
@@ -602,8 +733,18 @@ class HistoryTypeView(discord.ui.View):
     async def nickname(self, interaction: discord.Interaction, button: discord.ui.Button):
         await self.cog.show_member_list_nickname(interaction, self.alliance_id)
 
+    @discord.ui.button(label="Power Changes", emoji=f"{theme.upIcon}",
+                       style=discord.ButtonStyle.primary, row=1)
+    async def power(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.cog.show_member_list_power(interaction, self.alliance_id)
+
+    @discord.ui.button(label="Combat Power Changes", emoji=f"{theme.chartIcon}",
+                       style=discord.ButtonStyle.primary, row=1)
+    async def combat_power(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.cog.show_member_list_combat_power(interaction, self.alliance_id)
+
     @discord.ui.button(label="Back to Hub", emoji=f"{theme.backIcon}",
-                       style=discord.ButtonStyle.secondary, row=1)
+                       style=discord.ButtonStyle.secondary, row=2)
     async def back(self, interaction: discord.Interaction, button: discord.ui.Button):
         main_menu = self.cog.bot.get_cog("MainMenu")
         if main_menu and hasattr(main_menu, "show_alliance_hub"):
@@ -1095,6 +1236,123 @@ class NicknameHistoryIDSearchModal(discord.ui.Modal, title="Search by ID"):
                     f"{theme.deniedIcon} An error occurred while searching for the player.",
                     ephemeral=True
                 )
+
+class MemberListViewPower(discord.ui.View):
+    def __init__(self, cog, members, alliance_name, alliance_id, metric):
+        super().__init__(timeout=7200)
+        self.cog = cog
+        self.members = members
+        self.alliance_name = alliance_name
+        self.alliance_id = alliance_id
+        self.metric = metric
+        self.current_page = 0
+        self.total_pages = (len(members) + 24) // 25
+        self.update_view()
+
+    def update_view(self):
+        self.clear_items()
+
+        label = "Combat Power" if self.metric == "combat_power" else "Power"
+        start_idx = self.current_page * 25
+        end_idx = min(start_idx + 25, len(self.members))
+        current_members = self.members[start_idx:end_idx]
+
+        select = discord.ui.Select(
+            placeholder=f"Select a member (Page {self.current_page + 1}/{self.total_pages})",
+            options=[
+                discord.SelectOption(
+                    label=f"{name}",
+                    value=str(fid),
+                    description=f"ID: {fid} | {label}: {_fmt_power(val)}"
+                ) for fid, name, val in current_members
+            ],
+            row=0,
+        )
+
+        metric = self.metric
+
+        async def member_callback(interaction):
+            try:
+                fid = int(select.values[0])
+                await interaction.response.defer()
+                await self.cog.show_power_history(interaction, fid, metric)
+            except Exception as e:
+                logger.error(f"Error in MemberListViewPower member_callback: {e}")
+                if not interaction.response.is_done():
+                    await interaction.response.send_message(
+                        f"{theme.deniedIcon} An error occurred while showing {label.lower()} history.",
+                        ephemeral=True,
+                    )
+                else:
+                    await interaction.followup.send(
+                        f"{theme.deniedIcon} An error occurred while showing {label.lower()} history.",
+                        ephemeral=True,
+                    )
+
+        select.callback = member_callback
+        self.add_item(select)
+
+        if self.total_pages > 1:
+            previous_button = discord.ui.Button(
+                label="Previous",
+                emoji=f"{theme.backIcon}",
+                style=discord.ButtonStyle.secondary,
+                custom_id="previous_power",
+                disabled=self.current_page == 0,
+                row=1,
+            )
+            previous_button.callback = self.previous_callback
+            self.add_item(previous_button)
+
+            next_button = discord.ui.Button(
+                label="Next",
+                emoji=f"{theme.forwardIcon}",
+                style=discord.ButtonStyle.secondary,
+                custom_id="next_power",
+                disabled=self.current_page == self.total_pages - 1,
+                row=1,
+            )
+            next_button.callback = self.next_callback
+            self.add_item(next_button)
+
+        if self.alliance_id is not None:
+            back_button = discord.ui.Button(
+                label="Back",
+                emoji=f"{theme.backIcon}",
+                style=discord.ButtonStyle.secondary,
+                row=2,
+            )
+            back_button.callback = self._back_callback
+            self.add_item(back_button)
+
+    async def _back_callback(self, interaction: discord.Interaction):
+        await self.cog.show_history_for(interaction, self.alliance_id)
+
+    async def previous_callback(self, interaction: discord.Interaction):
+        self.current_page = max(0, self.current_page - 1)
+        await self.update_page(interaction)
+
+    async def next_callback(self, interaction: discord.Interaction):
+        self.current_page = min(self.total_pages - 1, self.current_page + 1)
+        await self.update_page(interaction)
+
+    async def update_page(self, interaction: discord.Interaction):
+        self.update_view()
+        label = "Combat Power" if self.metric == "combat_power" else "Power"
+        icon = theme.chartIcon
+        embed = discord.Embed(
+            title=f"{icon} {self.alliance_name} - Member List",
+            description=(
+                f"Select a member to view {label.lower()} history:\n"
+                f"{theme.upperDivider}\n"
+                f"Total Members: {len(self.members)}\n"
+                f"Current Page: {self.current_page + 1}/{self.total_pages}\n"
+                f"{theme.lowerDivider}"
+            ),
+            color=theme.emColor1,
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+
 
 class CustomTimeModal(discord.ui.Modal, title="Custom Time Range"):
     def __init__(self, cog, alliance_name):

--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -19,6 +19,7 @@ from .pimp_my_bot import theme, safe_edit_message, disable_expired_view
 from .process_queue import MEMBER_ADD, PreemptedException
 from .bot_level_mapping import LEVEL_MAPPING
 from .alliance import resolve_alliance_kid, state_lock_reason, STATE_CHECK_UNAVAILABLE
+from . import power_changes
 
 logger = logging.getLogger('alliance')
 
@@ -3427,6 +3428,9 @@ class AlliancePowerRankingsView(discord.ui.View):
         end = start + self.PAGE_SIZE
         page = self.members[start:end]
 
+        fids = [m[0] for m in self.members]
+        pdeltas = power_changes.latest_deltas(fids, "power")
+
         lines = [
             f"**Name** (`ID`) — **Power** — `CP` **Combat Power** · "
             f"times shown are last-updated.",
@@ -3441,8 +3445,9 @@ class AlliancePowerRankingsView(discord.ui.View):
                 if power is None:
                     lines.append(_ltr_line(f"{head} — *no power data yet*"))
                 else:
+                    badge = f"  {power_changes.format_delta(pdeltas[fid]['pct'])}" if fid in pdeltas else ""
                     lines.append(_ltr_line(
-                        f"{head} — {self._format_power(power)}{self._relative(power_at)}"))
+                        f"{head} — {self._format_power(power)}{self._relative(power_at)}{badge}"))
                     if cp is not None:
                         lines.append(_ltr_line(
                             f"      `CP` {self._format_power(cp)}{self._relative(cp_at)}"))

--- a/cogs/attendance_ocr_parsers.py
+++ b/cogs/attendance_ocr_parsers.py
@@ -14,6 +14,7 @@ from typing import Optional
 import discord
 
 from .pimp_my_bot import theme
+from . import power_changes
 
 logger = logging.getLogger("alliance")
 
@@ -969,26 +970,35 @@ def fuzzy_match_name(detected: str, roster: list[tuple[int, str]],
 
 
 def update_users_power(fid: int, power: int, ts_iso: str) -> None:
-    with sqlite3.connect("db/users.sqlite", timeout=30.0) as conn:
+    with sqlite3.connect(_USERS_DB, timeout=30.0) as conn:
+        row = conn.execute("SELECT power FROM users WHERE fid = ?", (fid,)).fetchone()
+        old = row[0] if row else None
         conn.execute(
             "UPDATE users SET power = ?, power_updated_at = ? WHERE fid = ?",
             (power, ts_iso, fid),
         )
         conn.commit()
+    power_changes.record_change(fid, "power", old, power, ts_iso)
 
 
 def update_users_combat_power(fid: int, combat_power: int, ts_iso: str) -> None:
-    with sqlite3.connect("db/users.sqlite", timeout=30.0) as conn:
+    with sqlite3.connect(_USERS_DB, timeout=30.0) as conn:
+        row = conn.execute(
+            "SELECT combat_power FROM users WHERE fid = ?", (fid,)
+        ).fetchone()
+        old = row[0] if row else None
         conn.execute(
             "UPDATE users SET combat_power = ?, combat_power_updated_at = ? WHERE fid = ?",
             (combat_power, ts_iso, fid),
         )
         conn.commit()
+    power_changes.record_change(fid, "combat_power", old, combat_power, ts_iso)
 
 
 # ── attendance session DB helpers ─────────────────────────────────────────
 
 _ATT_DB = "db/attendance.sqlite"
+_USERS_DB = "db/users.sqlite"
 
 # Min similarity to reuse a stored alias key when OCR drifts between screenshots.
 _OCR_ALIAS_FUZZY_MIN = 0.92

--- a/cogs/attendance_ocr_review.py
+++ b/cogs/attendance_ocr_review.py
@@ -15,6 +15,7 @@ import discord
 from .pimp_my_bot import theme
 from .bear_track import _isolate_rtl, _ltr_line
 from .login_handler import LoginHandler
+from . import power_changes
 from .attendance_ocr_parsers import (
     EVENT_TYPES,
     _STAT_LABELS,
@@ -988,6 +989,7 @@ class EventReviewView(discord.ui.View):
             else update_users_power
         )
         ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        self._last_ts = ts
 
         # Power Rankings is a power snapshot, not an event — write users.power for
         # matched rows and record no attendance.
@@ -1243,6 +1245,7 @@ class EventReviewView(discord.ui.View):
         cfg = EVENT_TYPES.get(self.session.event_type)
         label = cfg.label if cfg else self.session.event_type
         updated = getattr(self, "_power_updated_count", 0)
+        matched = [r for r in self.result_rows if r["fid"]]
         unmatched = [r for r in self.result_rows if not r["fid"]]
         desc = [
             f"{theme.upperDivider}",
@@ -1254,6 +1257,19 @@ class EventReviewView(discord.ui.View):
                 f"{theme.warnIcon} `{len(unmatched)}` unmatched row"
                 f"{'s' if len(unmatched) != 1 else ''} skipped — re-upload to assign them."
             )
+        if matched:
+            last_ts = getattr(self, "_last_ts", None)
+            fids = [r["fid"] for r in matched]
+            deltas = power_changes.deltas_at(fids, "power", last_ts) if last_ts else {}
+            sorted_matched = sorted(matched, key=lambda r: -(r["value"] or 0))
+            desc.append(f"**{theme.listIcon} Updated Players**")
+            for r in sorted_matched:
+                player = r.get("nickname") or r["name"]
+                badge = power_changes.format_delta(deltas[r["fid"]]["pct"]) if r["fid"] in deltas else ""
+                line = f"• **{player}** — `{_format_compact(r['value'])}`"
+                if badge:
+                    line += f"  {badge}"
+                desc.append(line)
         desc.append(f"{theme.lowerDivider}")
         return discord.Embed(
             title=f"{theme.verifiedIcon} {label} — Power Recorded",

--- a/cogs/power_changes.py
+++ b/cogs/power_changes.py
@@ -1,0 +1,130 @@
+"""Power / Combat Power change history: record, read, and format deltas."""
+import logging
+import sqlite3
+
+from .pimp_my_bot import theme
+
+logger = logging.getLogger(__name__)
+
+_CHANGES_DB = "db/changes.sqlite"
+
+METRICS = {
+    "power": {
+        "table": "power_changes",
+        "old_col": "old_power",
+        "new_col": "new_power",
+    },
+    "combat_power": {
+        "table": "combat_power_changes",
+        "old_col": "old_combat_power",
+        "new_col": "new_combat_power",
+    },
+}
+
+
+def ensure_tables() -> None:
+    with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
+        for m in METRICS.values():
+            conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {m['table']} ("
+                f"id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                f"fid INTEGER NOT NULL, "
+                f"{m['old_col']} INTEGER NOT NULL, "
+                f"{m['new_col']} INTEGER NOT NULL, "
+                f"change_date TEXT NOT NULL)"
+            )
+            conn.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{m['table']}_fid "
+                f"ON {m['table']}(fid)"
+            )
+        conn.commit()
+
+
+def _pct(old, new):
+    return ((new - old) / old * 100.0) if old else None
+
+
+def record_change(fid, metric, old_value, new_value, change_date) -> None:
+    if metric not in METRICS:
+        return
+    if old_value is None or new_value is None:
+        return
+    if int(new_value) == int(old_value) or not int(new_value):
+        return
+    m = METRICS[metric]
+    try:
+        ensure_tables()
+        with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
+            conn.execute(
+                f"INSERT INTO {m['table']} "
+                f"(fid, {m['old_col']}, {m['new_col']}, change_date) "
+                f"VALUES (?, ?, ?, ?)",
+                (fid, int(old_value), int(new_value), change_date),
+            )
+            conn.commit()
+    except Exception as e:
+        logger.error(f"record_change failed for fid={fid} metric={metric}: {e}")
+        print(f"record_change failed for fid={fid} metric={metric}: {e}")
+
+
+def _row_to_delta(old, new, change_date):
+    return {"old": old, "new": new, "pct": _pct(old, new), "change_date": change_date}
+
+
+def latest_delta(fid, metric):
+    if metric not in METRICS:
+        return None
+    m = METRICS[metric]
+    with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
+        row = conn.execute(
+            f"SELECT {m['old_col']}, {m['new_col']}, change_date FROM {m['table']} "
+            f"WHERE fid = ? ORDER BY change_date DESC, id DESC LIMIT 1",
+            (fid,),
+        ).fetchone()
+    return _row_to_delta(*row) if row else None
+
+
+def latest_deltas(fids, metric):
+    out = {}
+    for fid in fids:
+        d = latest_delta(fid, metric)
+        if d is not None:
+            out[fid] = d
+    return out
+
+
+def deltas_at(fids, metric, change_date):
+    if metric not in METRICS or not fids:
+        return {}
+    m = METRICS[metric]
+    placeholders = ",".join("?" for _ in fids)
+    with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
+        rows = conn.execute(
+            f"SELECT fid, {m['old_col']}, {m['new_col']}, change_date "
+            f"FROM {m['table']} WHERE change_date = ? AND fid IN ({placeholders})",
+            (change_date, *fids),
+        ).fetchall()
+    return {r[0]: _row_to_delta(r[1], r[2], r[3]) for r in rows}
+
+
+def history(fid, metric):
+    if metric not in METRICS:
+        return []
+    m = METRICS[metric]
+    with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
+        rows = conn.execute(
+            f"SELECT {m['old_col']}, {m['new_col']}, change_date FROM {m['table']} "
+            f"WHERE fid = ? ORDER BY change_date DESC, id DESC",
+            (fid,),
+        ).fetchall()
+    return [_row_to_delta(r[0], r[1], r[2]) for r in rows]
+
+
+def format_delta(pct) -> str:
+    if pct is None:
+        return theme.newIcon
+    if pct > 0:
+        return f"{theme.upIcon} +{pct:.0f}%"
+    if pct < 0:
+        return f"{theme.downIcon} {pct:.0f}%"
+    return f"{theme.forwardIcon} 0%"

--- a/cogs/power_changes.py
+++ b/cogs/power_changes.py
@@ -74,6 +74,7 @@ def _row_to_delta(old, new, change_date):
 def latest_delta(fid, metric):
     if metric not in METRICS:
         return None
+    ensure_tables()
     m = METRICS[metric]
     with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
         row = conn.execute(
@@ -85,17 +86,27 @@ def latest_delta(fid, metric):
 
 
 def latest_deltas(fids, metric):
+    if metric not in METRICS or not fids:
+        return {}
+    ensure_tables()
+    m = METRICS[metric]
+    placeholders = ",".join("?" for _ in fids)
+    with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
+        rows = conn.execute(
+            f"SELECT fid, {m['old_col']}, {m['new_col']}, change_date FROM {m['table']} "
+            f"WHERE fid IN ({placeholders}) ORDER BY change_date ASC, id ASC",
+            tuple(fids),
+        ).fetchall()
     out = {}
-    for fid in fids:
-        d = latest_delta(fid, metric)
-        if d is not None:
-            out[fid] = d
+    for r in rows:
+        out[r[0]] = _row_to_delta(r[1], r[2], r[3])  # ascending so last seen = most recent
     return out
 
 
 def deltas_at(fids, metric, change_date):
     if metric not in METRICS or not fids:
         return {}
+    ensure_tables()
     m = METRICS[metric]
     placeholders = ",".join("?" for _ in fids)
     with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
@@ -110,6 +121,7 @@ def deltas_at(fids, metric, change_date):
 def history(fid, metric):
     if metric not in METRICS:
         return []
+    ensure_tables()
     m = METRICS[metric]
     with sqlite3.connect(_CHANGES_DB, timeout=30.0) as conn:
         rows = conn.execute(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ pytz>=2025.2
 aiohttp-socks>=0.10.1
 python-dotenv>=1.1.0
 onnxruntime>=1.24.1
-rapidocr>=3.6.0
+# Cap below 3.9: newer rapidocr defaults to PP-OCRv6, which drops languages like
+# korean/japan/arabic. Lifting this needs a deliberate move to the new model set.
+rapidocr>=3.8.1,<3.9
 rapidfuzz>=3.14.0
 matplotlib>=3.10.5
 arabic-reshaper>=3.0.0

--- a/tests/test_power_changes.py
+++ b/tests/test_power_changes.py
@@ -1,0 +1,68 @@
+import sqlite3
+import pytest
+from cogs import power_changes as pc
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    path = tmp_path / "changes.sqlite"
+    monkeypatch.setattr(pc, "_CHANGES_DB", str(path))
+    pc.ensure_tables()
+    return str(path)
+
+
+def test_record_then_latest_delta(db):
+    pc.record_change(1, "power", 100, 150, "2026-06-27T10:00:00")
+    d = pc.latest_delta(1, "power")
+    assert d["old"] == 100 and d["new"] == 150
+    assert round(d["pct"], 1) == 50.0
+    assert d["change_date"] == "2026-06-27T10:00:00"
+
+
+def test_no_baseline_returns_none(db):
+    assert pc.latest_delta(99, "power") is None
+
+
+def test_record_skips_when_old_none_or_equal_or_zero(db):
+    pc.record_change(2, "power", None, 100, "t")     # first-ever: no baseline
+    pc.record_change(2, "power", 100, 100, "t")      # unchanged
+    pc.record_change(2, "power", 100, 0, "t")        # overwrite-to-zero ignored
+    assert pc.latest_delta(2, "power") is None
+
+
+def test_latest_delta_picks_most_recent(db):
+    pc.record_change(3, "power", 100, 200, "2026-01-01T00:00:00")
+    pc.record_change(3, "power", 200, 180, "2026-02-01T00:00:00")
+    d = pc.latest_delta(3, "power")
+    assert d["old"] == 200 and d["new"] == 180
+    assert d["pct"] < 0
+
+
+def test_deltas_at_filters_by_change_date(db):
+    pc.record_change(4, "power", 100, 200, "2026-01-01T00:00:00")
+    pc.record_change(4, "power", 200, 300, "2026-03-03T09:00:00")
+    at = pc.deltas_at([4, 5], "power", "2026-03-03T09:00:00")
+    assert set(at.keys()) == {4}
+    assert at[4]["new"] == 300
+
+
+def test_latest_deltas_batch(db):
+    pc.record_change(6, "power", 10, 20, "t1")
+    pc.record_change(7, "power", 50, 40, "t2")
+    out = pc.latest_deltas([6, 7, 8], "power")
+    assert out[6]["new"] == 20 and out[7]["new"] == 40
+    assert 8 not in out
+
+
+def test_history_newest_first(db):
+    pc.record_change(9, "combat_power", 100, 200, "2026-01-01T00:00:00")
+    pc.record_change(9, "combat_power", 200, 250, "2026-02-01T00:00:00")
+    h = pc.history(9, "combat_power")
+    assert [r["new"] for r in h] == [250, 200]
+
+
+def test_format_delta():
+    assert pc.format_delta(None) == pc.theme.newIcon
+    assert pc.format_delta(12.0) == f"{pc.theme.upIcon} +12%"
+    assert pc.format_delta(-7.0) == f"{pc.theme.downIcon} -7%"
+    assert pc.format_delta(0.0) == f"{pc.theme.forwardIcon} 0%"

--- a/tests/test_power_changes.py
+++ b/tests/test_power_changes.py
@@ -1,4 +1,3 @@
-import sqlite3
 import pytest
 from cogs import power_changes as pc
 
@@ -66,3 +65,12 @@ def test_format_delta():
     assert pc.format_delta(12.0) == f"{pc.theme.upIcon} +12%"
     assert pc.format_delta(-7.0) == f"{pc.theme.downIcon} -7%"
     assert pc.format_delta(0.0) == f"{pc.theme.forwardIcon} 0%"
+
+
+def test_reads_safe_on_cold_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(pc, "_CHANGES_DB", str(tmp_path / "cold.sqlite"))
+    # No ensure_tables() call here - reads must not raise on a missing table.
+    assert pc.latest_delta(1, "power") is None
+    assert pc.latest_deltas([1, 2], "power") == {}
+    assert pc.deltas_at([1], "power", "t") == {}
+    assert pc.history(1, "power") == []

--- a/tests/test_power_changes_hook.py
+++ b/tests/test_power_changes_hook.py
@@ -1,0 +1,40 @@
+import sqlite3
+import pytest
+from cogs import attendance_ocr_parsers as parsers
+from cogs import power_changes as pc
+
+
+@pytest.fixture
+def dbs(tmp_path, monkeypatch):
+    users = tmp_path / "users.sqlite"
+    changes = tmp_path / "changes.sqlite"
+    with sqlite3.connect(users) as conn:
+        conn.execute(
+            "CREATE TABLE users (fid INTEGER PRIMARY KEY, power INTEGER, "
+            "power_updated_at TEXT, combat_power INTEGER, combat_power_updated_at TEXT)"
+        )
+        conn.execute("INSERT INTO users (fid, power) VALUES (1, 100)")
+        conn.execute("INSERT INTO users (fid) VALUES (2)")  # no prior power
+        conn.commit()
+    monkeypatch.setattr(parsers, "_USERS_DB", str(users))
+    monkeypatch.setattr(pc, "_CHANGES_DB", str(changes))
+    pc.ensure_tables()
+    return str(users), str(changes)
+
+
+def test_update_records_change_when_value_differs(dbs):
+    parsers.update_users_power(1, 150, "2026-06-27T10:00:00")
+    d = pc.latest_delta(1, "power")
+    assert d["old"] == 100 and d["new"] == 150
+
+
+def test_first_ever_power_sets_baseline_no_change_row(dbs):
+    parsers.update_users_power(2, 500, "2026-06-27T10:00:00")
+    assert pc.latest_delta(2, "power") is None
+    with sqlite3.connect(dbs[0]) as conn:
+        assert conn.execute("SELECT power FROM users WHERE fid=2").fetchone()[0] == 500
+
+
+def test_reupload_same_value_no_change_row(dbs):
+    parsers.update_users_power(1, 100, "2026-06-27T10:00:00")
+    assert pc.latest_delta(1, "power") is None


### PR DESCRIPTION
## Power & Combat Power change tracking

Adds increase/decrease % tracking for member **Power** and **Combat Power**, mirroring the Bear Trap delta style. Power values were previously overwritten with no history; now every change is recorded and surfaced.

### What's added
- **`cogs/power_changes.py`** — single data layer: records changes into `db/changes.sqlite` (`power_changes` / `combat_power_changes`), reads them back, and formats the ⬆️/⬇️ % badge. Records only on a real change (no baseline rows, no zero/no-op writes), cold-DB safe, dynamic SQL restricted to a metric whitelist.
- **Recording hook** — `update_users_power` / `update_users_combat_power` capture the prior value and record the delta. Recording is isolated so it can never break a power write.
- **Three surfaces:**
  - Inline ⬆️/⬇️ % per player when a power screenshot is applied
  - Two new History views: **Power Changes** and **Combat Power Changes** (`old ➜ new` + %, newest first)
  - A latest-change badge in **Power Rankings**

### Testing
- New unit tests: `tests/test_power_changes.py`, `tests/test_power_changes_hook.py`

Also ported to Kingshot bot.