### PR TITLE
Redemption History, Summary and various gift code fixes and enhancements

### DIFF
--- a/cogs/gift_channels.py
+++ b/cogs/gift_channels.py
@@ -928,7 +928,7 @@ async def channel_history_scan(cog, interaction: discord.Interaction):
                 if existing_invalid > 0:
                     results_text += f"{theme.deniedIcon} Previously Invalid: {existing_invalid}\n"
                 if existing_pending > 0:
-                    results_text += f"{theme.warnIcon} Pending Validation: {existing_pending}\n"
+                    results_text += f"{theme.warnIcon} Validating: {existing_pending}\n"
 
                 results_text += f"\n{theme.editListIcon} **Note:** A detailed summary has been posted in #{channel.name}"
             else:

--- a/cogs/gift_operations.py
+++ b/cogs/gift_operations.py
@@ -118,6 +118,8 @@ class GiftOperations(commands.Cog):
         # Initialization of Locks and Cooldowns
         self.captcha_solver = None
         self._validation_lock = asyncio.Lock()
+        self._last_validation_claim_by_fid = {}  # fid -> monotonic ts of its last validation captcha request, for per-FID rate-spacing
+        self._priority_validation_pending = 0  # in-flight new-code validations; periodic loop yields while > 0
         self.last_validation_attempt_time = 0
         self.validation_cooldown = 5
         self._last_cleanup_date = None
@@ -145,39 +147,16 @@ class GiftOperations(commands.Cog):
 
         # Captcha Solver Initialization
         try:
-            self.settings_cursor.execute("""
-                CREATE TABLE IF NOT EXISTS ocr_settings (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    enabled INTEGER DEFAULT 1
-                )""")
-            self.settings_conn.commit()
-
-            self.settings_cursor.execute("SELECT enabled FROM ocr_settings ORDER BY id DESC LIMIT 1")
-            ocr_settings = self.settings_cursor.fetchone()
+            # Captcha solver is always on; disabling it isn't exposed (reload the
+            # Gift Code cog from Maintenance to restart it).
             save_captcha = getattr(self.bot, 'save_captcha', 0)
-
-            if ocr_settings:
-                enabled = ocr_settings[0]
-                if enabled == 1:
-                    self.logger.info("GiftOps __init__: OCR is enabled. Initializing ONNX solver...")
-                    self.captcha_solver = GiftCaptchaSolver(save_images=save_captcha)
-                    if not self.captcha_solver.is_initialized:
-                        self.logger.error("GiftOps __init__: ONNX solver FAILED to initialize.")
-                        self.captcha_solver = None
-                    else:
-                        self.logger.info("GiftOps __init__: ONNX solver initialized successfully.")
-                else:
-                    self.logger.info("GiftOps __init__: OCR is disabled in settings.")
+            self.logger.info("GiftOps __init__: Initializing ONNX captcha solver...")
+            self.captcha_solver = GiftCaptchaSolver(save_images=save_captcha)
+            if not self.captcha_solver.is_initialized:
+                self.logger.error("GiftOps __init__: ONNX solver FAILED to initialize.")
+                self.captcha_solver = None
             else:
-                self.logger.warning("GiftOps __init__: No OCR settings found in DB. Inserting defaults.")
-                self.settings_cursor.execute("INSERT INTO ocr_settings (enabled) VALUES (1)")
-                self.settings_conn.commit()
-                self.captcha_solver = GiftCaptchaSolver(save_images=save_captcha)
-                if not self.captcha_solver.is_initialized:
-                    self.logger.error("GiftOps __init__: ONNX solver FAILED to initialize with defaults.")
-                    self.captcha_solver = None
-                else:
-                    self.logger.info("GiftOps __init__: ONNX solver initialized successfully.")
+                self.logger.info("GiftOps __init__: ONNX solver initialized successfully.")
 
         except ImportError as lib_err:
             self.logger.exception(f"GiftOps __init__: Missing required library for OCR: {lib_err}. Captcha solving disabled.")
@@ -241,66 +220,16 @@ class GiftOperations(commands.Cog):
     async def on_ready(self):
         self.logger.info("GiftOps Cog: on_ready triggered.")
         try:
-            # Clean up old columns from ocr_settings if present
-            try:
-                self.logger.info("Checking ocr_settings table schema...")
-                conn_info = sqlite3.connect('db/settings.sqlite')
-                cursor_info = conn_info.cursor()
-                cursor_info.execute("PRAGMA table_info(ocr_settings)")
-                columns = [col[1] for col in cursor_info.fetchall()]
-                columns_to_drop = []
-                if 'use_gpu' in columns: columns_to_drop.append('use_gpu')
-                if 'gpu_device' in columns: columns_to_drop.append('gpu_device')
-                if 'save_images' in columns: columns_to_drop.append('save_images')
-
-                if columns_to_drop:
-                    sqlite_version = sqlite3.sqlite_version_info
-                    if sqlite_version >= (3, 35, 0):
-                        self.logger.info(f"Found old columns {columns_to_drop}. Attempting removal.")
-                        for col_name in columns_to_drop:
-                            try:
-                                self.settings_cursor.execute(f"ALTER TABLE ocr_settings DROP COLUMN {col_name}")
-                                self.logger.info(f"Successfully dropped column: {col_name}")
-                            except Exception as drop_err:
-                                self.logger.error(f"Error dropping column {col_name}: {drop_err}")
-                        self.settings_conn.commit()
-                    else:
-                        self.logger.warning(f"Found old columns {columns_to_drop}, but SQLite {sqlite3.sqlite_version} doesn't support DROP COLUMN.")
-                else:
-                    self.logger.info("ocr_settings table schema is up to date.")
-                conn_info.close()
-            except Exception as schema_err:
-                self.logger.error(f"Error during ocr_settings schema check/cleanup: {schema_err}")
-
-            self.logger.info("Setting up ocr_settings table...")
-            self.settings_cursor.execute("""
-                CREATE TABLE IF NOT EXISTS ocr_settings (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    enabled INTEGER DEFAULT 1
-                )
-            """)
-            self.settings_conn.commit()
-
-            self.settings_cursor.execute("SELECT COUNT(*) FROM ocr_settings")
-            count = self.settings_cursor.fetchone()[0]
-            if count == 0:
-                self.settings_cursor.execute("INSERT INTO ocr_settings (enabled) VALUES (1)")
-                self.settings_conn.commit()
-
+            # Captcha solver is always on; retry init here if __init__ failed.
             if self.captcha_solver is None:
-                self.logger.warning("Captcha solver not initialized in __init__, attempting again in on_ready...")
-                self.settings_cursor.execute("SELECT enabled FROM ocr_settings ORDER BY id DESC LIMIT 1")
-                ocr_settings = self.settings_cursor.fetchone()
-                if ocr_settings:
-                    enabled = ocr_settings[0]
-                    if enabled == 1:
-                        try:
-                            save_captcha = getattr(self.bot, 'save_captcha', 0)
-                            self.captcha_solver = GiftCaptchaSolver(save_images=save_captcha)
-                            if not self.captcha_solver.is_initialized:
-                                self.captcha_solver = None
-                        except Exception:
-                            self.captcha_solver = None
+                self.logger.warning("Captcha solver not initialized in __init__, retrying in on_ready...")
+                try:
+                    save_captcha = getattr(self.bot, 'save_captcha', 0)
+                    self.captcha_solver = GiftCaptchaSolver(save_images=save_captcha)
+                    if not self.captcha_solver.is_initialized:
+                        self.captcha_solver = None
+                except Exception:
+                    self.captcha_solver = None
 
             self.logger.info("Validating gift code channels...")
             self.cursor.execute("SELECT channel_id, alliance_id FROM giftcode_channel")
@@ -422,6 +351,8 @@ class GiftOperations(commands.Cog):
                 f"└ View all active, valid codes\n\n"
                 f"{theme.targetIcon} **Redeem Gift Code**\n"
                 f"└ Redeem gift code(s) for one or more alliances\n\n"
+                f"{theme.archiveIcon} **Redemption History**\n"
+                f"└ See which accounts redeemed, already had, or failed a code\n\n"
                 f"{theme.settingsIcon} **Settings**\n"
                 f"└ Set up a gift code channel, configure auto redemption, and more...\n\n"
                 f"{theme.trashIcon} **Delete Gift Code**\n"
@@ -435,8 +366,8 @@ class GiftOperations(commands.Cog):
 
     # ── Delegation to gift_redemption ─────────────────────────────────
 
-    async def validate_gift_code_immediately(self, giftcode, source="unknown"):
-        return await gift_redemption.validate_gift_code_immediately(self, giftcode, source)
+    async def validate_gift_code_immediately(self, giftcode, source="unknown", force=False):
+        return await gift_redemption.validate_gift_code_immediately(self, giftcode, source, force)
 
     def encode_data(self, data):
         return gift_redemption.encode_data(self, data)
@@ -525,17 +456,17 @@ class GiftOperations(commands.Cog):
     def get_test_fid(self):
         return gift_settings.get_test_fid(self)
 
+    def clear_test_fid(self):
+        return gift_settings.clear_test_fid(self)
+
     async def get_validation_fid(self):
         return await gift_settings.get_validation_fid(self)
 
-    async def show_ocr_settings(self, interaction):
-        return await gift_settings.show_ocr_settings(self, interaction)
-
-    async def update_ocr_settings(self, interaction, enabled=None):
-        return await gift_settings.update_ocr_settings(self, interaction, enabled)
-
     async def show_redemption_priority(self, interaction):
         return await gift_settings.show_redemption_priority(self, interaction)
+
+    async def show_redemption_summary(self, interaction):
+        return await gift_settings.show_redemption_summary(self, interaction)
 
     async def setup_giftcode_auto(self, interaction):
         return await gift_settings.setup_giftcode_auto(self, interaction)
@@ -556,6 +487,10 @@ class GiftOperations(commands.Cog):
 
     async def show_settings_menu(self, interaction):
         from .gift_views import show_settings_menu as _show
+        return await _show(self, interaction)
+
+    async def show_redeem_results(self, interaction):
+        from .gift_redemption_results import show_redeem_results as _show
         return await _show(self, interaction)
 
     async def get_admin_info(self, user_id):

--- a/cogs/gift_operationsapi.py
+++ b/cogs/gift_operationsapi.py
@@ -240,16 +240,21 @@ class GiftCodeAPI:
                             new_codes = []
                             for code, date_obj in valid_codes:
                                 formatted_date = date_obj.strftime("%Y-%m-%d")
-                                if code not in db_codes:
+                                prior = db_codes.get(code)
+                                if prior is None:
                                     try:
                                         # First add as pending
                                         self.cursor.execute(
                                             "INSERT OR IGNORE INTO gift_codes (giftcode, date, validation_status) VALUES (?, ?, ?)",
                                             (code, formatted_date, "pending")
                                         )
-                                        new_codes.append((code, formatted_date))
+                                        new_codes.append((code, formatted_date, False))
                                     except Exception as e:
                                         self.logger.exception(f"Error inserting new code {code}: {e}")
+                                elif prior[1] == 'invalid':
+                                    # API still distributing a code we hold invalid. Don't trust it -
+                                    # re-validate ourselves; only our own check can confirm a reactivation.
+                                    new_codes.append((code, formatted_date, True))
 
                             try:
                                 await self._safe_commit(self.conn, "new codes insertion")
@@ -261,72 +266,38 @@ class GiftCodeAPI:
                                     valid_codes_count = 0
                                     invalid_codes_count = 0
                                     
-                                    for code, formatted_date in new_codes:
+                                    for code, formatted_date, was_invalid in new_codes:
                                         try:
                                             # Get GiftOperations cog to validate
                                             gift_operations = self.bot.get_cog('GiftOperations')
                                             if gift_operations:
-                                                is_valid, validation_msg = await gift_operations.validate_gift_code_immediately(code, "api")
+                                                is_valid, validation_msg = await gift_operations.validate_gift_code_immediately(code, "api", force=was_invalid)
 
                                                 if is_valid is None:
-                                                    self.logger.warning(f"API code '{code}' validation inconclusive on first attempt: {validation_msg}. Retrying...")
-
-                                                    for retry_num in range(1, 4):
-                                                        await asyncio.sleep(5)
-                                                        self.logger.info(f"Retry {retry_num}/3 for code '{code}'")
-                                                        is_valid, validation_msg = await gift_operations.validate_gift_code_immediately(code, "api")
-
-                                                        if is_valid is not None:
-                                                            break
-
-                                                    if is_valid is None:
-                                                        self.logger.warning(f"API code '{code}' still inconclusive after 3 retries. Marking as pending.")
+                                                    # Inconclusive (usually the FID's captcha cooldown). Don't rapid-retry
+                                                    # here - that just sustains the throttle. The serialized, spaced
+                                                    # re-validation chain below picks it up cleanly.
+                                                    self.logger.info(f"API code '{code}' not conclusively validated yet ({validation_msg}); scheduling spaced re-validation.")
 
                                                 if is_valid:
                                                     valid_codes_count += 1
                                                     self.logger.info(f"API code '{code}' validated successfully")
 
-                                                    # Check if this code was previously invalid (reactivation detection)
-                                                    is_reactivated = False
+                                                    # A code we held invalid that our OWN re-validation now confirms valid
+                                                    # is a genuine reactivation: clear old redemptions so members can claim again.
                                                     cleared_redemptions = 0
-
-                                                    try:
-                                                        self.cursor.execute(
-                                                            "SELECT validation_status FROM gift_codes WHERE giftcode = ?",
-                                                            (code,)
-                                                        )
-                                                        previous_status_row = self.cursor.fetchone()
-
-                                                        if previous_status_row and previous_status_row[0] == 'invalid':
-                                                            # This is a REACTIVATED code - clear all user redemption history
-                                                            self.logger.info(f"🔄 REACTIVATION DETECTED: Code '{code}' was invalid, now valid again")
-
-                                                            # Count existing redemptions before clearing
-                                                            self.cursor.execute(
-                                                                "SELECT COUNT(*) FROM user_giftcodes WHERE giftcode = ?",
-                                                                (code,)
-                                                            )
+                                                    if was_invalid:
+                                                        try:
+                                                            self.cursor.execute("SELECT COUNT(*) FROM user_giftcodes WHERE giftcode = ?", (code,))
                                                             count_row = self.cursor.fetchone()
                                                             cleared_redemptions = count_row[0] if count_row else 0
-
-                                                            # Clear all user redemption records for this code
-                                                            self.cursor.execute(
-                                                                "DELETE FROM user_giftcodes WHERE giftcode = ?",
-                                                                (code,)
-                                                            )
+                                                            self.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ?", (code,))
                                                             await self._safe_commit(self.conn, f"clear redemption history for reactivated code {code}")
+                                                            self.logger.info(f"🔄 REACTIVATION: '{code}' re-validated valid; cleared {cleared_redemptions} old redemption records")
+                                                        except Exception as e:
+                                                            self.logger.error(f"Error clearing reactivation history for code '{code}': {e}")
 
-                                                            self.logger.info(f"✅ Cleared {cleared_redemptions} redemption records for reactivated code '{code}'")
-                                                            is_reactivated = True
-
-                                                    except Exception as e:
-                                                        self.logger.error(f"Error checking/clearing reactivation status for code '{code}': {e}")
-
-                                                    # Set validation status message
-                                                    if is_reactivated:
-                                                        validation_status = f"✅ Validated (🔄 REACTIVATED - {cleared_redemptions} redemptions cleared)"
-                                                    else:
-                                                        validation_status = "✅ Validated"
+                                                    validation_status = f"✅ Validated (🔄 Reactivated - {cleared_redemptions} cleared)" if was_invalid else "✅ Validated"
 
                                                     try:
                                                         await self._execute_with_retry(
@@ -350,7 +321,7 @@ class GiftCodeAPI:
                                                     auto_alliances = []
                                                 else:
                                                     self.logger.warning(f"API code '{code}' validation inconclusive after retries: {validation_msg}")
-                                                    validation_status = f"{theme.warnIcon} Pending"
+                                                    validation_status = f"{theme.warnIcon} Validating"
                                                     auto_alliances = []
                                                     # Re-test soon instead of waiting for the 2h periodic loop.
                                                     gift_operations.schedule_revalidation(code, "api")
@@ -359,9 +330,13 @@ class GiftCodeAPI:
                                                 validation_status = f"{theme.deniedIcon} Error"
                                                 auto_alliances = []
 
+                                            # A code we already held invalid that didn't re-validate as valid isn't
+                                            # news (avoids re-notifying every sync when the API keeps distributing it).
+                                            notify = (not was_invalid) or (is_valid is True)
+
                                             self.settings_cursor.execute("SELECT id FROM admin WHERE is_initial = 1")
                                             admin_ids = self.settings_cursor.fetchall()
-                                            if admin_ids:
+                                            if notify and admin_ids:
                                                 embed_description = (
                                                     f"**Gift Code Details**\n"
                                                     f"{theme.upperDivider}\n"
@@ -370,12 +345,16 @@ class GiftCodeAPI:
                                                     f"{theme.listIcon} **Validation Status:** `{validation_status}`\n"
                                                     f"{theme.linkIcon} **Source:** `Retrieved from Bot API`\n"
                                                     f"{theme.alarmClockIcon} **Time:** <t:{int(datetime.now().timestamp())}:R>\n"
-                                                    f"{theme.refreshIcon} **Auto Alliance Count:** `{len(auto_alliances)}`\n"
                                                 )
 
-                                                if is_valid is None:
+                                                if is_valid:
+                                                    if auto_alliances:
+                                                        embed_description += f"{theme.refreshIcon} **Auto-redemption:** Queued for `{len(auto_alliances)}` Alliances\n"
+                                                    else:
+                                                        embed_description += f"{theme.refreshIcon} **Auto-redemption** is not enabled\n"
+                                                elif is_valid is None:
                                                     from . import gift_redemption
-                                                    embed_description += f"\n{gift_redemption.PENDING_REVALIDATION_NOTICE}\n"
+                                                    embed_description += f"{gift_redemption.PENDING_REVALIDATION_NOTICE}\n"
 
                                                 embed_description += f"{theme.lowerDivider}\n"
 
@@ -400,14 +379,23 @@ class GiftCodeAPI:
                                                 self.cursor.execute("SELECT DISTINCT channel_id FROM giftcode_channel")
                                                 gift_channels = self.cursor.fetchall()
 
-                                                if gift_channels:
+                                                if notify and gift_channels:
+                                                    channel_desc = (
+                                                        f"**Code:** `{code}`\n"
+                                                        f"**Status:** {validation_status}\n"
+                                                    )
+                                                    if is_valid:
+                                                        if auto_alliances:
+                                                            channel_desc += f"**Auto-redemption:** Queued for {len(auto_alliances)} Alliances"
+                                                        else:
+                                                            channel_desc += "**Auto-redemption** is not enabled"
+                                                    elif is_valid is None:
+                                                        channel_desc += "**Auto-redemption:** Runs automatically as soon as the code validates"
+                                                    else:
+                                                        channel_desc += "**Auto-redemption:** Not redeemed (code is invalid)"
                                                     channel_embed = discord.Embed(
                                                         title="🎁 New Gift Code Retrieved",
-                                                        description=(
-                                                            f"**Code:** `{code}`\n"
-                                                            f"**Status:** {validation_status}\n"
-                                                            f"**Auto-redemption:** {'Started' if auto_alliances else 'Disabled'}"
-                                                        ),
+                                                        description=channel_desc,
                                                         color=embed_color
                                                     )
                                                     channel_embed.set_footer(text="Retrieved via Gift Code Distribution API")

--- a/cogs/gift_redemption.py
+++ b/cogs/gift_redemption.py
@@ -71,13 +71,13 @@ async def enqueue_redemption(cog, giftcode, alliance_id, source='manual', batch_
 
 # Shown when a new code can't be confirmed yet; schedule_revalidation re-tests it within minutes.
 PENDING_REVALIDATION_NOTICE = (
-    "⏳ Auto-redemption pending - couldn't confirm the code yet. It'll be "
-    "automatically re-tested over the next few minutes; redemption starts as "
-    "soon as it validates. You can also trigger the redemption manually if needed."
+    "⏳ Not confirmed yet - re-checking automatically; it redeems as soon as it validates."
 )
 
-# Backoff (seconds) for re-testing an inconclusive new code: 1m, 2m, 5m, 15m, then the 2h loop.
-_REVALIDATION_BACKOFFS = [60, 120, 300, 900]
+# Backoff (seconds) for re-testing an inconclusive new code, then the 2h loop.
+# Never sub-60s: the usual cause is WOS's per-FID captcha cooldown (~60s), and
+# retrying sooner just sustains the CAPTCHA_TOO_FREQUENT throttle.
+_REVALIDATION_BACKOFFS = [60, 120, 300, 600, 900]
 
 
 async def handle_gift_validate_process(cog, process):
@@ -105,13 +105,16 @@ async def handle_gift_validate_process(cog, process):
             except Exception:
                 message = None
 
-    # Check if code already exists
-    cog.cursor.execute("SELECT 1 FROM gift_codes WHERE giftcode = ?", (giftcode,))
-    if cog.cursor.fetchone():
+    # A code we hold as 'invalid' that shows up again is a reactivation candidate:
+    # re-validate it instead of bailing. Other stored statuses stay "already exists".
+    cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (giftcode,))
+    row = cog.cursor.fetchone()
+    if row and row[0] != 'invalid':
         cog.logger.info(f"Code '{giftcode}' already exists in database.")
         if message and channel:
             await _send_existing_code_response(cog, message, giftcode, channel)
         return
+    was_invalid = row is not None and row[0] == 'invalid'
 
     # Show processing message if from channel
     processing_message = None
@@ -126,15 +129,25 @@ async def handle_gift_validate_process(cog, process):
         except Exception:
             processing_message = None
 
-    # Perform validation
-    is_valid, validation_msg = await validate_gift_code_immediately(cog, giftcode, source)
+    # Perform validation (force a live re-probe for a reactivation candidate).
+    is_valid, validation_msg = await validate_gift_code_immediately(cog, giftcode, source, force=was_invalid)
 
     # Handle validation result
     if message and channel:
         await _send_validation_response(cog, message, giftcode, is_valid, validation_msg, processing_message)
 
-    # Valid -> redeem; inconclusive -> re-test on a short backoff (else the 2h loop).
+    # Valid -> share to API + redeem; inconclusive -> re-test on a short backoff.
     if is_valid:
+        if was_invalid:
+            # Genuine reactivation: clear old redemptions so members can claim again.
+            try:
+                cog.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ?", (giftcode,))
+                cog.conn.commit()
+                cog.logger.info(f"🔄 REACTIVATION: '{giftcode}' re-validated valid via {source}; cleared old redemption records")
+            except Exception as e:
+                cog.logger.error(f"Error clearing reactivation history for '{giftcode}': {e}")
+        if hasattr(cog, 'api') and cog.api:
+            asyncio.create_task(cog.api.add_giftcode(giftcode))
         await _process_auto_use(cog, giftcode)
     elif is_valid is None:
         schedule_revalidation(cog, giftcode, source)
@@ -266,7 +279,7 @@ async def _send_validation_response(cog, message, giftcode, is_valid, validation
         )
         reaction = f"{theme.deniedIcon}"
     else:
-        reply_embed = discord.Embed(title=f"{theme.warnIcon} Gift Code Added (Pending)", color=discord.Color.yellow())
+        reply_embed = discord.Embed(title=f"{theme.warnIcon} Gift Code Added (Validating)", color=discord.Color.yellow())
         reply_embed.description = (
             f"**Gift Code Details**\n{theme.upperDivider}\n"
             f"{theme.userIcon} **Sender:** {message.author.mention}\n"
@@ -553,16 +566,61 @@ async def _update_batch_progress(cog, batch_id):
         cog.logger.warning(f"Failed to update batch progress message: {e}")
 
 
-async def validate_gift_code_immediately(cog, giftcode, source="unknown"):
-    """Immediately validate a gift code when it's added from any source.
+# Conclusive validation outcomes: the API gave a definitive verdict on the code.
+VALID_REDEEM_STATUSES = ("SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE", "TOO_SMALL_SPEND_MORE", "TOO_POOR_SPEND_MORE")
+INVALID_REDEEM_STATUSES = ("TIME_ERROR", "CDK_NOT_FOUND", "USAGE_LIMIT")
+CONCLUSIVE_REDEEM_STATUSES = VALID_REDEEM_STATUSES + INVALID_REDEEM_STATUSES
 
-    Args:
-        giftcode: The gift code to validate
-        source: Where the code came from ('api', 'button', 'channel')
+# WOS rate-limits captcha GET per-FID, so serialize + space validation by >=60s per FID
+# (matches the JS bot's RATE_LIMIT_DELAY; going lower just sustains the throttle).
+VALIDATION_CAPTCHA_INTERVAL = 60.0
 
-    Returns:
-        tuple: (is_valid, status_message)
-    """
+
+async def serialized_validation_claim(cog, fid, giftcode):
+    """Serialized, per-FID rate-spaced validation captcha request. New-code validations
+    run through here and take priority - the periodic loop yields while any are pending."""
+    cog._priority_validation_pending = getattr(cog, '_priority_validation_pending', 0) + 1
+    try:
+        async with cog._validation_lock:
+            stamps = cog._last_validation_claim_by_fid
+            wait = VALIDATION_CAPTCHA_INTERVAL - (time.monotonic() - stamps.get(str(fid), 0.0))
+            if wait > 0:
+                cog.logger.info(f"GiftOps: spacing validation captcha for '{giftcode}' on FID {fid} - waiting {wait:.0f}s")
+                await asyncio.sleep(wait)
+            try:
+                return await claim_giftcode_rewards_wos(cog, fid, giftcode, skip_cache=True)
+            finally:
+                now = time.monotonic()
+                stamps[str(fid)] = now
+                # Prune stale entries so the per-FID dict can't grow unbounded over time.
+                for k in [k for k, v in stamps.items() if now - v > VALIDATION_CAPTCHA_INTERVAL * 2]:
+                    del stamps[k]
+    finally:
+        cog._priority_validation_pending -= 1
+
+
+async def get_alt_validation_fids(cog, exclude, limit=3):
+    """Random alliance-member FIDs to validate with when the primary FID is throttled or dead."""
+    def _query():
+        with sqlite3.connect('db/users.sqlite', timeout=30.0) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT fid FROM users WHERE alliance IS NOT NULL AND alliance != '' ORDER BY RANDOM() LIMIT ?",
+                (limit + len(exclude),),
+            )
+            return [row[0] for row in cursor.fetchall()]
+    try:
+        fids = await asyncio.to_thread(_query)
+    except Exception as e:
+        cog.logger.warning(f"GiftOps: could not fetch alternate validation FIDs: {e}")
+        return []
+    excl = {str(e) for e in exclude}
+    return [f for f in fids if str(f) not in excl][:limit]
+
+
+async def validate_gift_code_immediately(cog, giftcode, source="unknown", force=False):
+    """Validate a code against the live game API. Returns (is_valid, message).
+    force=True re-probes even a code already stored as validated/invalid (reactivation)."""
     try:
         # Clean the gift code
         giftcode = cog.clean_gift_code(giftcode)
@@ -572,25 +630,35 @@ async def validate_gift_code_immediately(cog, giftcode, source="unknown"):
 
         cog.logger.info(f"Validating gift code '{giftcode}' from {source} using {fid_source} ID: {validation_fid}")
 
-        # Check if already validated
-        cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (giftcode,))
-        existing = cog.cursor.fetchone()
+        # Short-circuit on a known verdict unless forced to re-probe (e.g. reactivation).
+        if not force:
+            cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (giftcode,))
+            existing = cog.cursor.fetchone()
+            if existing:
+                status = existing[0]
+                if status == 'invalid':
+                    cog.logger.info(f"Gift code '{giftcode}' already marked as invalid")
+                    return False, "Code already marked as invalid"
+                elif status == 'validated':
+                    cog.logger.info(f"Gift code '{giftcode}' already validated")
+                    return True, "Code already validated"
 
-        if existing:
-            status = existing[0]
-            if status == 'invalid':
-                cog.logger.info(f"Gift code '{giftcode}' already marked as invalid")
-                return False, "Code already marked as invalid"
-            elif status == 'validated':
-                cog.logger.info(f"Gift code '{giftcode}' already validated")
-                return True, "Code already validated"
+        # Perform validation through the serialized, rate-spaced gate so concurrent
+        # immediate/backoff chains don't collide on the test FID's captcha cooldown.
+        status = await serialized_validation_claim(cog, validation_fid, giftcode)
 
-        # Perform validation using the selected ID — skip the cache so we
-        # actually probe the live API (the whole point of validating).
-        status = await claim_giftcode_rewards_wos(cog, validation_fid, giftcode, skip_cache=True)
+        # If the primary FID gave no definitive verdict (usually a persistent per-FID
+        # captcha throttle), rotate to fresh member FIDs that aren't throttled so a
+        # valid code gets confirmed now instead of parking as "Validating".
+        if status not in CONCLUSIVE_REDEEM_STATUSES:
+            for alt_fid in await get_alt_validation_fids(cog, exclude={validation_fid}):
+                cog.logger.info(f"Validation of '{giftcode}' inconclusive on FID {validation_fid} ({status}); retrying with member FID {alt_fid}")
+                status = await serialized_validation_claim(cog, alt_fid, giftcode)
+                if status in CONCLUSIVE_REDEEM_STATUSES:
+                    break
 
         # Handle validation results
-        if status in ["SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE", "TOO_SMALL_SPEND_MORE", "TOO_POOR_SPEND_MORE"]:
+        if status in VALID_REDEEM_STATUSES:
             # Valid code - mark as validated
             cog.cursor.execute("""
                 INSERT OR REPLACE INTO gift_codes (giftcode, date, validation_status)
@@ -608,7 +676,7 @@ async def validate_gift_code_immediately(cog, giftcode, source="unknown"):
 
             return True, validation_msg
 
-        elif status in ["TIME_ERROR", "CDK_NOT_FOUND", "USAGE_LIMIT"]:
+        elif status in INVALID_REDEEM_STATUSES:
             # Invalid code - mark as invalid
             mark_code_invalid(cog, giftcode)
 
@@ -649,19 +717,147 @@ def encode_data(cog, data):
     return {"sign": sign, **data}
 
 
+# Bidi isolates so RTL names (Arabic/Hebrew) don't flip surrounding LTR text.
+_FSI = "⁨"
+_PDI = "⁩"
+
+
+def _iso(text) -> str:
+    return f"{_FSI}{text}{_PDI}"
+
+
+def get_summary_settings(cog, alliance_id):
+    """Per-alliance redemption-summary config; None-safe, defaults to disabled."""
+    try:
+        cog.settings_cursor.execute(
+            "SELECT enabled, show_success, show_already, show_failed "
+            "FROM redemption_summary_settings WHERE alliance_id = ?",
+            (alliance_id,),
+        )
+        row = cog.settings_cursor.fetchone()
+    except Exception:
+        return {"enabled": 0, "success": 0, "already": 0, "failed": 0}
+    if not row:
+        return {"enabled": 0, "success": 0, "already": 0, "failed": 0}
+    return {"enabled": row[0], "success": row[1], "already": row[2], "failed": row[3]}
+
+
+def set_summary_settings(cog, alliance_id, *, enabled=None, success=None, already=None, failed=None):
+    cur = get_summary_settings(cog, alliance_id)
+    enabled = cur["enabled"] if enabled is None else int(enabled)
+    success = cur["success"] if success is None else int(success)
+    already = cur["already"] if already is None else int(already)
+    failed = cur["failed"] if failed is None else int(failed)
+    cog.settings_cursor.execute(
+        "INSERT INTO redemption_summary_settings "
+        "(alliance_id, enabled, show_success, show_already, show_failed) VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(alliance_id) DO UPDATE SET enabled = excluded.enabled, "
+        "show_success = excluded.show_success, show_already = excluded.show_already, "
+        "show_failed = excluded.show_failed",
+        (alliance_id, enabled, success, already, failed),
+    )
+    cog.settings_conn.commit()
+
+
+def _summary_names_block(names, limit=1024) -> str:
+    """One name per line, truncated to fit `limit` chars, with an overflow pointer to Redemption History."""
+    out, used = [], 0
+    for n in names:
+        need = len(n) + 1  # + newline
+        if used + need > limit - 45:  # reserve room for the overflow note
+            break
+        out.append(n)
+        used += need
+    text = "\n".join(out)
+    more = len(names) - len(out)
+    if more > 0:
+        text += f"\n…and {more} more - see Redemption History"
+    return text
+
+
+async def post_redemption_summary(cog, channel, alliance_id, alliance_name, giftcode,
+                                  successful_users, already_used_users, failed_users_dict):
+    """Post the opt-in per-alliance summary as up to three static, silent messages
+    (Redeemed / Already Redeemed / Failed). Separate messages so each gets its own
+    embed budget; silent so they don't ping alongside the redemption progress post.
+    No buttons - it's a persistent public log; the filterable per-player view is the
+    on-demand, in-menu Redemption History screen."""
+    if channel is None:
+        return
+    s = get_summary_settings(cog, alliance_id)
+    if not s or not s["enabled"]:
+        return
+
+    head = f"Alliance: **{alliance_name}**"
+
+    async def _post(embed):
+        try:
+            try:
+                await channel.send(embed=embed, silent=True)
+            except TypeError:  # older discord.py without silent=
+                await channel.send(embed=embed)
+        except Exception as e:
+            cog.logger.exception(f"GiftOps: Error posting redemption summary for {alliance_id}: {e}")
+
+    if s["success"] and successful_users:
+        block = _summary_names_block([_iso(n) for n in successful_users], 3800)
+        await _post(discord.Embed(
+            title=f"{theme.verifiedIcon} Redeemed - {giftcode} ({len(successful_users)})",
+            description=f"{head}\n\n{block}", color=theme.emColor3))
+
+    if s["already"] and already_used_users:
+        block = _summary_names_block([_iso(n) for n in already_used_users], 3800)
+        await _post(discord.Embed(
+            title=f"{theme.giftIcon} Already Redeemed - {giftcode} ({len(already_used_users)})",
+            description=f"{head}\n\n{block}", color=theme.emColor1))
+
+    if s["failed"] and failed_users_dict:
+        by_reason = {}
+        for fid, (nick, reason, _cycles) in failed_users_dict.items():
+            by_reason.setdefault(reason, []).append(f"{_iso(nick)} ({fid})")
+        embed = discord.Embed(
+            title=f"{theme.deniedIcon} Failed - {giftcode} ({len(failed_users_dict)})",
+            description=head, color=theme.emColor2)
+        total = len(head)
+        for reason, names in sorted(by_reason.items(), key=lambda kv: len(kv[1]), reverse=True):
+            value = _summary_names_block(names, 1024)
+            if len(embed.fields) >= 24 or total + len(reason) + len(value) > 5800:
+                embed.add_field(name="…", value="More players listed in Redemption History.", inline=False)
+                break
+            embed.add_field(name=f"{theme.deniedIcon} {reason}", value=value, inline=False)
+            total += len(reason) + len(value)
+        await _post(embed)
+        if self.message:
+            try:
+                await self.message.edit(view=self)
+            except Exception:
+                pass
+
+
 def batch_insert_user_giftcodes(cog, user_giftcode_data):
-    """Batch insert/update user giftcode records for better performance."""
+    """Batch upsert per-account redemption results (success and failure).
+
+    Never downgrades an existing SUCCESS/RECEIVED/SAME TYPE EXCHANGE to a later
+    failure (an account that succeeded on retry stays successful), and refreshes
+    last_attempt_at so the redeem-results viewer can show when it last ran.
+    """
     if not user_giftcode_data:
         return
 
-    try: # Executemany for batch operations - much faster than individual inserts
+    ts = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    rows = [(fid, giftcode, status, ts) for (fid, giftcode, status) in user_giftcode_data]
+    try:
         cog.cursor.executemany("""
-            INSERT OR REPLACE INTO user_giftcodes (fid, giftcode, status)
-            VALUES (?, ?, ?)
-        """, user_giftcode_data)
+            INSERT INTO user_giftcodes (fid, giftcode, status, last_attempt_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(fid, giftcode) DO UPDATE SET
+                status = excluded.status,
+                last_attempt_at = excluded.last_attempt_at
+            WHERE user_giftcodes.status NOT IN ('SUCCESS', 'RECEIVED', 'SAME TYPE EXCHANGE')
+        """, rows)
 
         cog.conn.commit()
-        cog.logger.info(f"GiftOps: Batch inserted/updated {len(user_giftcode_data)} user giftcode records")
+        cog.logger.info(f"GiftOps: Recorded {len(rows)} user giftcode result(s)")
 
     except Exception as e:
         cog.logger.exception(f"GiftOps: Error in batch_insert_user_giftcodes: {e}")
@@ -736,24 +932,20 @@ def batch_process_alliance_results(cog, results_batch):
         return
 
     try:
-        # Separate successful results
-        successful_records = []
-        codes_to_validate = set()
+        codes_to_validate = {
+            giftcode for fid, giftcode, status in results_batch
+            if status in ["SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE"]
+        }
 
-        for fid, giftcode, status in results_batch:
-            if status in ["SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE"]:
-                successful_records.append((fid, giftcode, status))
-                codes_to_validate.add(giftcode)
+        # Persist every per-account outcome (success and failure) so Redeem
+        # History has the full picture; the upsert never downgrades a success.
+        batch_insert_user_giftcodes(cog, results_batch)
 
-        # Batch insert successful records
-        if successful_records:
-            batch_insert_user_giftcodes(cog, successful_records)
-
-        # Batch validate codes
+        # Batch validate codes (only codes that had at least one success)
         if codes_to_validate:
             batch_update_gift_codes_validation(cog, list(codes_to_validate))
 
-        cog.logger.info(f"GiftOps: Batch processed {len(successful_records)} successful, {len(codes_to_validate)} validated")
+        cog.logger.info(f"GiftOps: Batch processed {len(results_batch)} result(s), {len(codes_to_validate)} validated")
 
     except Exception as e:
         cog.logger.exception(f"GiftOps: Error in batch_process_alliance_results: {e}")
@@ -967,14 +1159,10 @@ async def claim_giftcode_rewards_wos(cog, player_id, giftcode, *, skip_cache: bo
                         cog.logger.info(f"CACHE HIT - User {player_id} code '{giftcode}' status: {status}")
                         return status
 
-        # Check if OCR Enabled and Solver Ready
-        cog.settings_cursor.execute("SELECT enabled FROM ocr_settings ORDER BY id DESC LIMIT 1")
-        ocr_settings_row = cog.settings_cursor.fetchone()
-        ocr_enabled = ocr_settings_row[0] if ocr_settings_row else 0
-
-        if not (ocr_enabled == 1 and cog.captcha_solver):
-            status = "OCR_DISABLED" if ocr_enabled == 0 else "SOLVER_ERROR"
-            log_msg = f"{datetime.now()} Skipping captcha: OCR disabled (Enabled={ocr_enabled}) or Solver not ready ({cog.captcha_solver is None}) for ID {player_id}.\n"
+        # Captcha solver is always on; only skip if it failed to initialize.
+        if not cog.captcha_solver:
+            status = "SOLVER_ERROR"
+            log_msg = f"{datetime.now()} Skipping captcha: solver not ready for ID {player_id}.\n"
             cog.logger.info(log_msg.strip())
             return status
 
@@ -1229,6 +1417,12 @@ async def scan_historical_messages(cog, channel: discord.TextChannel, alliance_i
                 # Store validation result
                 scan_results['validation_results'][giftcode] = is_valid
 
+                # Valid -> share to the API and auto-redeem for enabled alliances.
+                if is_valid:
+                    if hasattr(cog, 'api') and cog.api:
+                        asyncio.create_task(cog.api.add_giftcode(giftcode))
+                    await _process_auto_use(cog, giftcode)
+
                 # Add appropriate reaction to message
                 if giftcode in message_code_map:
                     message = message_code_map[giftcode]
@@ -1346,7 +1540,7 @@ async def _send_scan_results_message(cog, channel: discord.TextChannel, results:
         if results['existing_invalid']:
             existing_summary += f"{theme.deniedIcon} Previously Invalid: {len(results['existing_invalid'])}\n"
         if results['existing_pending']:
-            existing_summary += f"{theme.warnIcon} Pending Validation: {len(results['existing_pending'])}\n"
+            existing_summary += f"{theme.warnIcon} Validating: {len(results['existing_pending'])}\n"
 
         if existing_summary:
             embed.add_field(
@@ -1415,112 +1609,119 @@ async def periodic_validation_loop_body(cog):
             await cleanup_old_invalid_codes(cog)
             cog._last_cleanup_date = current_date
 
-        # Check if validation is already in progress to avoid conflicts
-        async with cog._validation_lock:
-            # Get codes that need validation (pending or validated)
-            cog.cursor.execute("""
-                SELECT giftcode, validation_status
-                FROM gift_codes
-                WHERE validation_status IN ('pending', 'validated')
-            """)
-            codes_to_check = cog.cursor.fetchall()
+        # Validate one code at a time, locking per code (not the whole run) so an
+        # interactive add isn't blocked behind the entire loop.
+        # Get codes that need validation (pending or validated)
+        cog.cursor.execute("""
+            SELECT giftcode, validation_status
+            FROM gift_codes
+            WHERE validation_status IN ('pending', 'validated')
+        """)
+        codes_to_check = cog.cursor.fetchall()
 
-            if not codes_to_check:
-                cog.logger.info("GiftOps: No codes need periodic validation.")
-                return
+        if not codes_to_check:
+            cog.logger.info("GiftOps: No codes need periodic validation.")
+            return
 
-            cog.logger.info(f"GiftOps: Found {len(codes_to_check)} codes to validate periodically.")
+        cog.logger.info(f"GiftOps: Found {len(codes_to_check)} codes to validate periodically.")
 
-            # Get test ID for validation
-            test_fid, fid_source = await cog.get_validation_fid()
-            cog.logger.info(f"GiftOps: Using {fid_source} ID {test_fid} for periodic validation.")
+        # Get test ID for validation
+        test_fid, fid_source = await cog.get_validation_fid()
+        cog.logger.info(f"GiftOps: Using {fid_source} ID {test_fid} for periodic validation.")
 
-            codes_checked = 0
-            codes_invalidated = 0
-            codes_still_valid = 0
+        codes_checked = 0
+        codes_invalidated = 0
+        codes_still_valid = 0
 
-            for giftcode, current_status in codes_to_check:
-                # Skip if we've checked too many codes (to prevent long-running loops)
-                if codes_checked >= 20:
-                    cog.logger.info("GiftOps: Reached periodic validation limit of 20 codes per run.")
-                    break
+        for giftcode, current_status in codes_to_check:
+            # Skip if we've checked too many codes (to prevent long-running loops)
+            if codes_checked >= 20:
+                cog.logger.info("GiftOps: Reached periodic validation limit of 20 codes per run.")
+                break
 
-                try:
-                    cog.logger.info(f"GiftOps: Periodically validating code '{giftcode}' (current status: {current_status})")
+            # New codes are top priority: yield while any interactive/new-code
+            # validation is pending so periodic checks never delay them.
+            while getattr(cog, '_priority_validation_pending', 0) > 0:
+                await asyncio.sleep(0.5)
 
-                    # Check the code with test ID — skip cache so a previously
-                    # redeemed code still gets probed against the live API.
+            try:
+                cog.logger.info(f"GiftOps: Periodically validating code '{giftcode}' (current status: {current_status})")
+
+                # Check the code with test ID — skip cache so a previously
+                # redeemed code still gets probed against the live API.
+                async with cog._validation_lock:
                     status = await claim_giftcode_rewards_wos(cog, test_fid, giftcode, skip_cache=True)
-                    codes_checked += 1
+                    cog._last_validation_claim_by_fid[str(test_fid)] = time.monotonic()  # share the clock so immediate validations space off this FID
+                codes_checked += 1
 
-                    if status in ["TIME_ERROR", "CDK_NOT_FOUND", "USAGE_LIMIT"]: # Code is now invalid
-                        cog.logger.info(f"GiftOps: Code '{giftcode}' is now invalid (status: {status}). Updating database.")
+                if status in INVALID_REDEEM_STATUSES: # Code is now invalid
+                    cog.logger.info(f"GiftOps: Code '{giftcode}' is now invalid (status: {status}). Updating database.")
 
-                        cog.cursor.execute("UPDATE gift_codes SET validation_status = 'invalid' WHERE giftcode = ?", (giftcode,))
-                        # Clear redemption status for the test fid
-                        cog.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ? AND fid = ?", (giftcode, test_fid))
+                    cog.cursor.execute("UPDATE gift_codes SET validation_status = 'invalid' WHERE giftcode = ?", (giftcode,))
+                    # Clear redemption status for the test fid
+                    cog.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ? AND fid = ?", (giftcode, test_fid))
+                    cog.conn.commit()
+
+                    codes_invalidated += 1
+
+                    # Remove from API if present
+                    if hasattr(cog, 'api') and cog.api:
+                        asyncio.create_task(cog.api.remove_giftcode(giftcode, from_validation=True))
+
+                    # Notify admins about invalidated code
+                    await _dm_global_admins(cog, discord.Embed(
+                        title=f"{theme.deniedIcon} Gift Code Invalidated",
+                        description=f"Code `{giftcode}` has been invalidated during periodic validation.\nStatus: {status}",
+                        color=theme.emColor2,
+                        timestamp=datetime.now()
+                    ))
+
+                elif status in VALID_REDEEM_STATUSES:
+                    codes_still_valid += 1
+
+                    if current_status == 'pending':
+                        cog.logger.info(f"GiftOps: Code '{giftcode}' confirmed valid. Updating status to 'validated'.")
+                        cog.cursor.execute("UPDATE gift_codes SET validation_status = 'validated' WHERE giftcode = ? AND validation_status = 'pending'", (giftcode,))
                         cog.conn.commit()
 
-                        codes_invalidated += 1
-
-                        # Remove from API if present
                         if hasattr(cog, 'api') and cog.api:
-                            asyncio.create_task(cog.api.remove_giftcode(giftcode, from_validation=True))
+                            asyncio.create_task(cog.api.add_giftcode(giftcode))
 
-                        # Notify admins about invalidated code
-                        await _dm_global_admins(cog, discord.Embed(
-                            title=f"{theme.deniedIcon} Gift Code Invalidated",
-                            description=f"Code `{giftcode}` has been invalidated during periodic validation.\nStatus: {status}",
-                            color=theme.emColor2,
-                            timestamp=datetime.now()
-                        ))
+                        try:
+                            await cog._execute_with_retry(
+                                lambda: cog.cursor.execute("SELECT alliance_id FROM giftcodecontrol WHERE status = 1 ORDER BY priority ASC, alliance_id ASC")
+                            )
+                            auto_alliances = cog.cursor.fetchall() or []
+                        except sqlite3.OperationalError as e:
+                            error_msg = f"Auto-alliance query failed after retries for code '{giftcode}': {e}"
+                            cog.logger.error(error_msg)
+                            print(f"ERROR: {error_msg}")
+                            auto_alliances = []
+                        except Exception as e:
+                            error_msg = f"Unexpected error in auto-alliance query for code '{giftcode}': {e}"
+                            cog.logger.error(error_msg)
+                            print(f"ERROR: {error_msg}")
+                            auto_alliances = []
 
-                    elif status in ["SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE", "TOO_SMALL_SPEND_MORE", "TOO_POOR_SPEND_MORE"]:
-                        codes_still_valid += 1
+                        await start_auto_redemption(cog, giftcode, auto_alliances, source='periodic-auto')
 
-                        if current_status == 'pending':
-                            cog.logger.info(f"GiftOps: Code '{giftcode}' confirmed valid. Updating status to 'validated'.")
-                            cog.cursor.execute("UPDATE gift_codes SET validation_status = 'validated' WHERE giftcode = ? AND validation_status = 'pending'", (giftcode,))
-                            cog.conn.commit()
+                else:
+                    cog.logger.info(f"GiftOps: Code '{giftcode}' returned status '{status}' during periodic validation.")
 
-                            if hasattr(cog, 'api') and cog.api:
-                                asyncio.create_task(cog.api.add_giftcode(giftcode))
+                    # Extra delay for CAPTCHA_TOO_FREQUENT errors
+                    if status == "CAPTCHA_TOO_FREQUENT":
+                        cog.logger.info(f"GiftOps: Encountered CAPTCHA_TOO_FREQUENT, waiting 60-90 seconds before next validation")
+                        await asyncio.sleep(random.uniform(60.0, 90.0))
+                        continue
 
-                            try:
-                                await cog._execute_with_retry(
-                                    lambda: cog.cursor.execute("SELECT alliance_id FROM giftcodecontrol WHERE status = 1 ORDER BY priority ASC, alliance_id ASC")
-                                )
-                                auto_alliances = cog.cursor.fetchall() or []
-                            except sqlite3.OperationalError as e:
-                                error_msg = f"Auto-alliance query failed after retries for code '{giftcode}': {e}"
-                                cog.logger.error(error_msg)
-                                print(f"ERROR: {error_msg}")
-                                auto_alliances = []
-                            except Exception as e:
-                                error_msg = f"Unexpected error in auto-alliance query for code '{giftcode}': {e}"
-                                cog.logger.error(error_msg)
-                                print(f"ERROR: {error_msg}")
-                                auto_alliances = []
+                # Wait between validations to avoid rate limiting
+                await asyncio.sleep(random.uniform(30.0, 60.0))
 
-                            await start_auto_redemption(cog, giftcode, auto_alliances, source='periodic-auto')
+            except Exception as e:
+                cog.logger.exception(f"Error validating code '{giftcode}' during periodic check: {e}")
+                await asyncio.sleep(5) # Longer wait on error
 
-                    else:
-                        cog.logger.info(f"GiftOps: Code '{giftcode}' returned status '{status}' during periodic validation.")
-
-                        # Extra delay for CAPTCHA_TOO_FREQUENT errors
-                        if status == "CAPTCHA_TOO_FREQUENT":
-                            cog.logger.info(f"GiftOps: Encountered CAPTCHA_TOO_FREQUENT, waiting 60-90 seconds before next validation")
-                            await asyncio.sleep(random.uniform(60.0, 90.0))
-                            continue
-
-                    # Wait between validations to avoid rate limiting
-                    await asyncio.sleep(random.uniform(30.0, 60.0))
-
-                except Exception as e:
-                    cog.logger.exception(f"Error validating code '{giftcode}' during periodic check: {e}")
-                    await asyncio.sleep(5) # Longer wait on error
-
-            cog.logger.info(f"GiftOps: Periodic validation complete. Checked: {codes_checked}, Invalidated: {codes_invalidated}, Still valid: {codes_still_valid}")
+        cog.logger.info(f"GiftOps: Periodic validation complete. Checked: {codes_checked}, Invalidated: {codes_invalidated}, Still valid: {codes_still_valid}")
 
         loop_end_time = datetime.now()
         cog.logger.info(f"GiftOps: periodic_validation_loop finished at {loop_end_time.strftime('%Y-%m-%d %H:%M:%S')}. Duration: {loop_end_time - loop_start_time}\n")
@@ -1610,19 +1811,15 @@ async def use_giftcode_for_alliance(cog, alliance_id, giftcode):
             cog.logger.error(f"GiftOps: Bot cannot access channel {channel_id} for alliance {alliance_name}.")
             return False
 
-        # Check if OCR is enabled
-        cog.settings_cursor.execute("SELECT enabled FROM ocr_settings ORDER BY id DESC LIMIT 1")
-        ocr_settings_row = cog.settings_cursor.fetchone()
-        ocr_enabled = ocr_settings_row[0] if ocr_settings_row else 0
-
-        if not (ocr_enabled == 1 and cog.captcha_solver):
+        # Captcha solver is always on; only bail if it failed to initialize.
+        if not cog.captcha_solver:
             error_embed = discord.Embed(
-                title=f"{theme.deniedIcon} OCR/Captcha Solver Disabled",
+                title=f"{theme.deniedIcon} Captcha Solver Not Ready",
                 description=(
                     f"**Gift Code:** `{giftcode}`\n"
                     f"**Alliance:** `{alliance_name}`\n\n"
-                    f"{theme.warnIcon} Gift code redemption requires the OCR/captcha solver to be enabled.\n"
-                    f"Please enable it first using the settings command."
+                    f"{theme.warnIcon} The captcha solver failed to initialize, so redemption can't run.\n"
+                    f"Reload the Gift Code cog from Maintenance, or check the logs."
                 ),
                 color=theme.emColor2
             )
@@ -2081,6 +2278,12 @@ async def use_giftcode_for_alliance(cog, alliance_id, giftcode):
         if batch_results:
             batch_process_alliance_results(cog, batch_results)
             batch_results = []
+
+        # Opt-in per-alliance summary embed after the run.
+        await post_redemption_summary(
+            cog, channel, alliance_id, alliance_name, giftcode,
+            successful_users, already_used_users, failed_users_dict,
+        )
 
         return True
 

--- a/cogs/gift_redemption_results.py
+++ b/cogs/gift_redemption_results.py
@@ -1,0 +1,334 @@
+"""Gift code Redemption History viewer: per-account outcomes (redeemed / already
+redeemed / failed) for a chosen code, paginated and filterable by alliance."""
+
+import asyncio
+import sqlite3
+import logging
+
+import discord
+
+from .pimp_my_bot import theme, safe_edit_message, check_interaction_user, disable_expired_view
+from .permission_handler import PermissionManager
+
+logger = logging.getLogger('gift')
+
+PAGE_SIZE = 20
+
+# Reuse the proven RTL helpers shared with bear_track / attendance: an LRM prefix
+# keeps the whole line left-to-right (so icons/numbers/parens stay in order) while
+# each RTL name is wrapped in an FSI…PDI isolate.
+from .bear_track import _isolate_rtl, _ltr_line
+
+
+SUCCESS_STATUSES = {"SUCCESS", "SAME TYPE EXCHANGE"}
+ALREADY_STATUSES = {"RECEIVED"}
+# The code itself is bad/expired — not a per-account outcome. Shown as a banner.
+CODE_LEVEL_STATUSES = {"CDK_NOT_FOUND", "USAGE_LIMIT", "TIME_ERROR"}
+
+STATUS_LABELS = {
+    "SUCCESS": "Redeemed",
+    "SAME TYPE EXCHANGE": "Redeemed",
+    "RECEIVED": "Already redeemed",
+    "CONNECTION_ERROR": "Connection error",
+    "CAPTCHA_INVALID": "Captcha failed",
+    "ERROR": "Error",
+}
+
+BUCKET_ORDER = ("success", "already", "failed")
+BUCKET_META = {
+    "success": ("Redeemed", "verifiedIcon"),
+    "already": ("Already Redeemed", "giftIcon"),
+    "failed": ("Failed", "deniedIcon"),
+}
+
+
+def _bucket(status: str) -> str:
+    if status in SUCCESS_STATUSES:
+        return "success"
+    if status in ALREADY_STATUSES:
+        return "already"
+    if status in CODE_LEVEL_STATUSES:
+        return "code"
+    return "failed"
+
+
+def _load_results(giftcode: str, cursor_rows):
+    """Merge redemption rows (giftcode.sqlite) with nicknames/alliance."""
+    fids = [r[0] for r in cursor_rows]
+    users = {}
+    if fids:
+        with sqlite3.connect('db/users.sqlite', timeout=30.0) as uconn:
+            ucur = uconn.cursor()
+            for i in range(0, len(fids), 500):
+                chunk = fids[i:i + 500]
+                placeholders = ",".join("?" * len(chunk))
+                ucur.execute(
+                    f"SELECT fid, nickname, alliance FROM users WHERE fid IN ({placeholders})",
+                    chunk,
+                )
+                for fid, nickname, alliance in ucur.fetchall():
+                    users[fid] = (nickname, alliance)
+
+    rows = []
+    for fid, status, ts in cursor_rows:
+        nickname, alliance = users.get(fid, (None, None))
+        rows.append({
+            "fid": fid,
+            "nickname": nickname or str(fid),
+            "alliance": str(alliance) if alliance is not None else None,
+            "status": status,
+            "bucket": _bucket(status),
+            "ts": ts,
+        })
+    return rows
+
+
+async def show_redeem_results(cog, interaction: discord.Interaction):
+    """Entry point from the main Gift Code menu."""
+    is_admin, _ = PermissionManager.is_admin(interaction.user.id)
+    if not is_admin:
+        msg = f"{theme.deniedIcon} Only bot admins can view redeem history."
+        if interaction.response.is_done():
+            await interaction.followup.send(msg, ephemeral=True)
+        else:
+            await interaction.response.send_message(msg, ephemeral=True)
+        return
+
+    cog.cursor.execute("SELECT giftcode, date FROM gift_codes ORDER BY date DESC LIMIT 25")
+    codes = cog.cursor.fetchall()
+    alliances, is_global = PermissionManager.get_admin_alliances(
+        interaction.user.id, interaction.guild_id or 0
+    )
+    allowed_ids = None if is_global else {str(aid) for aid, _ in alliances}
+
+    view = RedeemHistoryView(cog, interaction.user.id, codes, alliances, allowed_ids)
+    await safe_edit_message(interaction, embed=view.build_embed(), view=view, content=None)
+    view.message = await interaction.original_response()
+
+
+class RedeemHistoryView(discord.ui.View):
+    """One-screen Redemption History: code dropdown + alliance filter + status
+    toggles + pagination. Everything but the code dropdown and Back is disabled
+    until a code is selected."""
+
+    def __init__(self, cog, user_id, codes, alliances, allowed_ids):
+        super().__init__(timeout=7200)
+        self.cog = cog
+        self.user_id = user_id
+        self.codes = codes                  # [(giftcode, date), ...]
+        self.alliances = alliances          # [(alliance_id, name), ...]
+        self.allowed_ids = allowed_ids      # None => global (all)
+        self.message = None
+
+        self.selected_code = None
+        self.all_rows = []                  # permission-scoped rows for selected code
+        self.alliance_filter = None         # None => all accessible
+        self.active_buckets = set(BUCKET_ORDER)
+        self.page = 0
+        self._build_components()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_interaction_user(interaction, self.user_id)
+
+    # --- data helpers ---------------------------------------------------
+    def _alliance_rows(self):
+        if self.alliance_filter is None:
+            return self.all_rows
+        return [r for r in self.all_rows if r["alliance"] == self.alliance_filter]
+
+    def _counts(self, rows):
+        counts = {"success": 0, "already": 0, "failed": 0, "code": 0}
+        for r in rows:
+            counts[r["bucket"]] = counts.get(r["bucket"], 0) + 1
+        return counts
+
+    def _visible_rows(self, rows):
+        return [r for r in rows if r["bucket"] in self.active_buckets]
+
+    def _alliance_name(self, alliance_id):
+        for aid, name in self.alliances:
+            if str(aid) == str(alliance_id):
+                return name
+        return f"Alliance {alliance_id}"
+
+    # --- rendering ------------------------------------------------------
+    def build_embed(self) -> discord.Embed:
+        if not self.codes:
+            return discord.Embed(
+                title=f"{theme.archiveIcon} Redemption History",
+                description="No gift codes have been added yet.",
+                color=theme.emColor1,
+            )
+        if self.selected_code is None:
+            return discord.Embed(
+                title=f"{theme.archiveIcon} Redemption History",
+                description=(
+                    "Pick a gift code above to see which accounts redeemed it, "
+                    "already had it, or failed."
+                ),
+                color=theme.emColor1,
+            )
+
+        arows = self._alliance_rows()
+        counts = self._counts(arows)
+        visible = self._visible_rows(arows)
+
+        total_pages = max(1, (len(visible) + PAGE_SIZE - 1) // PAGE_SIZE)
+        self.page = max(0, min(self.page, total_pages - 1))
+        page_rows = visible[self.page * PAGE_SIZE:(self.page + 1) * PAGE_SIZE]
+
+        header = (
+            f"{theme.verifiedIcon} Redeemed: `{counts['success']}`  "
+            f"{theme.giftIcon} Already: `{counts['already']}`  "
+            f"{theme.deniedIcon} Failed: `{counts['failed']}`"
+        )
+
+        lines = []
+        if counts["code"]:
+            lines.append(
+                f"{theme.warnIcon} This code looks invalid or expired for "
+                f"`{counts['code']}` account(s) (bad/expired code)."
+            )
+            lines.append("")
+
+        if not page_rows:
+            lines.append("_No accounts match the current filters._")
+        else:
+            icons = {b: getattr(theme, BUCKET_META[b][1]) for b in BUCKET_ORDER}
+            for r in page_rows:
+                label = STATUS_LABELS.get(r["status"], r["status"])
+                name = _isolate_rtl(r["nickname"])
+                lines.append(_ltr_line(f"{icons[r['bucket']]} **{name}** (`{r['fid']}`) - {label}"))
+
+        scope = "All alliances" if self.alliance_filter is None else self._alliance_name(self.alliance_filter)
+        return discord.Embed(
+            title=f"{theme.archiveIcon} Redemption History - {self.selected_code}",
+            description=(
+                f"{header}\n"
+                f"{theme.upperDivider}\n"
+                + "\n".join(lines)
+                + f"\n{theme.lowerDivider}\n"
+                f"Scope: **{scope}**  ·  Page **{self.page + 1}/{total_pages}**"
+            ),
+            color=theme.emColor1,
+        )
+
+    def _build_components(self):
+        self.clear_items()
+        has_code = self.selected_code is not None
+
+        # Row 0: gift code picker (always active).
+        if self.codes:
+            options = [
+                discord.SelectOption(
+                    label=code[:100],
+                    description=(f"Added {date}" if date else None),
+                    value=code,
+                    default=code == self.selected_code,
+                )
+                for code, date in self.codes
+            ]
+            code_select = discord.ui.Select(
+                placeholder="Pick a gift code", options=options, row=0,
+            )
+            code_select.callback = self._on_code
+            self.add_item(code_select)
+
+        # Row 1: alliance filter (only when more than one is accessible).
+        if self.alliances and len(self.alliances) > 1:
+            opts = [discord.SelectOption(
+                label="All alliances", value="__all__",
+                default=self.alliance_filter is None,
+            )]
+            for aid, name in self.alliances[:24]:
+                opts.append(discord.SelectOption(
+                    label=name[:100], value=str(aid),
+                    default=str(aid) == str(self.alliance_filter),
+                ))
+            asel = discord.ui.Select(
+                placeholder="Filter by alliance", options=opts, row=1, disabled=not has_code,
+            )
+            asel.callback = self._on_alliance
+            self.add_item(asel)
+
+        # Row 2: status filter toggles with live counts (disabled until a code).
+        counts = self._counts(self._alliance_rows())
+        for bucket in BUCKET_ORDER:
+            title, icon_name = BUCKET_META[bucket]
+            on = bucket in self.active_buckets
+            btn = discord.ui.Button(
+                label=f"{title} ({counts[bucket]})",
+                emoji=getattr(theme, icon_name),
+                style=discord.ButtonStyle.success if on else discord.ButtonStyle.secondary,
+                row=2,
+                disabled=not has_code,
+            )
+            btn.callback = self._make_toggle(bucket)
+            self.add_item(btn)
+
+        # Row 3: pagination (disabled until a code).
+        prev_btn = discord.ui.Button(label="Prev", emoji=f"{theme.prevIcon}", style=discord.ButtonStyle.primary, row=3, disabled=not has_code)
+        prev_btn.callback = self._prev
+        self.add_item(prev_btn)
+        next_btn = discord.ui.Button(label="Next", emoji=f"{theme.nextIcon}", style=discord.ButtonStyle.primary, row=3, disabled=not has_code)
+        next_btn.callback = self._next
+        self.add_item(next_btn)
+
+        # Row 4: Back only (returns to the gift menu).
+        back_btn = discord.ui.Button(label="Back", emoji=f"{theme.backIcon}", style=discord.ButtonStyle.secondary, row=4)
+        back_btn.callback = self._back
+        self.add_item(back_btn)
+
+    async def _refresh(self, interaction: discord.Interaction):
+        self._build_components()
+        await safe_edit_message(interaction, embed=self.build_embed(), view=self, content=None)
+
+    # --- callbacks ------------------------------------------------------
+    async def _on_code(self, interaction: discord.Interaction):
+        self.selected_code = interaction.data["values"][0]
+        await interaction.response.defer()
+        self.cog.cursor.execute(
+            "SELECT fid, status, last_attempt_at FROM user_giftcodes WHERE giftcode = ?",
+            (self.selected_code,),
+        )
+        cursor_rows = self.cog.cursor.fetchall()
+        rows = await asyncio.to_thread(_load_results, self.selected_code, cursor_rows)
+        if self.allowed_ids is None:
+            self.all_rows = rows
+        else:
+            self.all_rows = [r for r in rows if r["alliance"] in self.allowed_ids]
+        self.alliance_filter = None
+        self.active_buckets = set(BUCKET_ORDER)
+        self.page = 0
+        self._build_components()
+        await safe_edit_message(interaction, embed=self.build_embed(), view=self, content=None)
+
+    async def _on_alliance(self, interaction: discord.Interaction):
+        value = interaction.data["values"][0]
+        self.alliance_filter = None if value == "__all__" else value
+        self.page = 0
+        await self._refresh(interaction)
+
+    def _make_toggle(self, bucket):
+        async def _toggle(interaction: discord.Interaction):
+            if bucket in self.active_buckets:
+                self.active_buckets.discard(bucket)
+            else:
+                self.active_buckets.add(bucket)
+            self.page = 0
+            await self._refresh(interaction)
+        return _toggle
+
+    async def _prev(self, interaction: discord.Interaction):
+        self.page -= 1
+        await self._refresh(interaction)
+
+    async def _next(self, interaction: discord.Interaction):
+        self.page += 1
+        await self._refresh(interaction)
+
+    async def _back(self, interaction: discord.Interaction):
+        await self.cog.show_gift_menu(interaction)
+
+    async def on_timeout(self):
+        await disable_expired_view(self)

--- a/cogs/gift_settings.py
+++ b/cogs/gift_settings.py
@@ -9,9 +9,10 @@ import requests
 import json
 import traceback
 
-from .pimp_my_bot import theme, safe_edit_message
+from .pimp_my_bot import theme, safe_edit_message, check_interaction_user, notify_view_expired
 from .gift_captchasolver import GiftCaptchaSolver
 from .alliance_member_operations import AllianceSelectView
+from .permission_handler import PermissionManager
 
 logger = logging.getLogger('gift')
 
@@ -171,200 +172,43 @@ async def get_validation_fid(cog):
         return "45379845", 'default'
 
 
-async def show_ocr_settings(cog, interaction: discord.Interaction):
-        """Show OCR settings menu."""
-        try:
-            cog.settings_cursor.execute("SELECT is_initial FROM admin WHERE id = ?", (interaction.user.id,))
-            admin_info = cog.settings_cursor.fetchone()
+def build_solver_status_field(cog):
+    """(name, value) embed field: solver status, validation-FID mode, and redemption stats."""
+    if cog.captcha_solver and getattr(cog.captcha_solver, "is_initialized", False):
+        solver_status = f"{theme.verifiedIcon} Ready"
+    elif cog.captcha_solver is not None:
+        solver_status = f"{theme.warnIcon} Init failed (check logs)"
+    else:
+        solver_status = f"{theme.deniedIcon} Not loaded (reload the Gift Code cog)"
 
-            if not admin_info or admin_info[0] != 1:
-                error_msg = f"{theme.deniedIcon} Only global administrators can access OCR settings."
-                if interaction.response.is_done():
-                    await interaction.followup.send(error_msg, ephemeral=True)
-                else:
-                    await interaction.response.send_message(error_msg, ephemeral=True)
-                return
+    test_fid = get_test_fid(cog)
+    fid_line = f"`{test_fid}` (fixed)" if test_fid and test_fid != "45379845" else "Rotating alliance members"
 
-            cog.settings_cursor.execute("SELECT enabled FROM ocr_settings ORDER BY id DESC LIMIT 1")
-            ocr_settings = cog.settings_cursor.fetchone()
+    stats = cog.processing_stats
+    submissions = stats["captcha_submissions"]
+    s_ok = stats["server_validation_success"]
+    s_fail = stats["server_validation_failure"]
+    pass_rate = (s_ok / (s_ok + s_fail) * 100) if (s_ok + s_fail) > 0 else 0
 
-            if not ocr_settings:
-                cog.logger.warning("No OCR settings found in DB, inserting defaults.")
-                cog.settings_cursor.execute("INSERT INTO ocr_settings (enabled) VALUES (1)")
-                cog.settings_conn.commit()
-                ocr_settings = (1,)
-
-            enabled = ocr_settings[0]
-            current_test_fid = get_test_fid(cog)
-
-            onnx_available = False
-            solver_status_msg = "N/A"
-            if cog.captcha_solver:
-                if cog.captcha_solver.is_initialized:
-                    onnx_available = True
-                    solver_status_msg = "Initialized & Ready"
-                elif hasattr(cog.captcha_solver, 'is_initialized'):
-                    onnx_available = True
-                    solver_status_msg = "Initialization Failed (Check Logs)"
-                else:
-                    solver_status_msg = "Error (Instance missing flags)"
-            else:
-                try:
-                    # Suppress ONNX C++ GPU warning (writes to fd 2, not sys.stderr)
-                    import sys, os as _os
-                    _fd, _null = sys.stderr.fileno(), _os.open(_os.devnull, _os.O_WRONLY)
-                    _bak = _os.dup(_fd); _os.dup2(_null, _fd); _os.close(_null)
-                    import onnxruntime
-                    _os.dup2(_bak, _fd); _os.close(_bak)
-                    onnx_available = True
-                    solver_status_msg = "Disabled or Init Failed"
-                except ImportError:
-                    onnx_available = False
-                    solver_status_msg = "onnxruntime library missing"
-
-            embed = discord.Embed(
-                title=f"{theme.searchIcon} CAPTCHA Solver Settings (ONNX)",
-                description=(
-                    f"Configure the automatic CAPTCHA solver for gift code redemption.\n\n"
-                    f"**Current Settings**\n"
-                    f"{theme.upperDivider}\n"
-                    f"{theme.robotIcon} **OCR Enabled:** {f'{theme.verifiedIcon} Yes' if enabled == 1 else f'{theme.deniedIcon} No'}\n"
-                    f"{theme.fidIcon} **Test ID:** `{current_test_fid}`\n"
-                    f"{theme.giftIcon} **ONNX Runtime:** {f'{theme.verifiedIcon} Found' if onnx_available else f'{theme.deniedIcon} Missing'}\n"
-                    f"{theme.settingsIcon} **Solver Status:** `{solver_status_msg}`\n"
-                    f"{theme.lowerDivider}\n"
-                ),
-                color=theme.emColor1
-            )
-
-            if not onnx_available:
-                embed.add_field(
-                    name=f"{theme.warnIcon} Missing Library",
-                    value=(
-                        "ONNX Runtime and required libraries are needed for CAPTCHA solving.\n"
-                        "The model files must be in the bot/models/ directory.\n"
-                        "Try installing dependencies:\n"
-                        "```pip install onnxruntime pillow numpy\n"
-                    ), inline=False
-                )
-
-            stats_lines = []
-            stats_lines.append("**Captcha Solver (Raw Format):**")
-            ocr_calls = cog.processing_stats['ocr_solver_calls']
-            ocr_valid = cog.processing_stats['ocr_valid_format']
-            ocr_format_rate = (ocr_valid / ocr_calls * 100) if ocr_calls > 0 else 0
-            stats_lines.append(f"• Solver Calls: `{ocr_calls}`")
-            stats_lines.append(f"• Valid Format Returns: `{ocr_valid}` ({ocr_format_rate:.1f}%)")
-
-            stats_lines.append("\n**Redemption Process (Server Side):**")
-            submissions = cog.processing_stats['captcha_submissions']
-            server_success = cog.processing_stats['server_validation_success']
-            server_fail = cog.processing_stats['server_validation_failure']
-            total_server_val = server_success + server_fail
-            server_pass_rate = (server_success / total_server_val * 100) if total_server_val > 0 else 0
-            stats_lines.append(f"• Captcha Submissions: `{submissions}`")
-            stats_lines.append(f"• Server Validation Success: `{server_success}`")
-            stats_lines.append(f"• Server Validation Failure: `{server_fail}`")
-            stats_lines.append(f"• Server Pass Rate: `{server_pass_rate:.1f}%`")
-
-            total_fids = cog.processing_stats['total_fids_processed']
-            total_time = cog.processing_stats['total_processing_time']
-            avg_time = (total_time / total_fids if total_fids > 0 else 0)
-            stats_lines.append(f"• Avg. ID Processing Time: `{avg_time:.2f}s` (over `{total_fids}` IDs)")
-
-            embed.add_field(
-                name=f"{theme.chartIcon} Processing Statistics (Since Bot Start)",
-                value="\n".join(stats_lines),
-                inline=False
-            )
-
-            view = OCRSettingsView(cog, enabled, onnx_available)
-
-            if interaction.response.is_done():
-                try:
-                    await interaction.edit_original_response(embed=embed, view=view)
-                except discord.NotFound:
-                    await interaction.followup.send(embed=embed, view=view, ephemeral=True)
-                except Exception as e_edit:
-                    cog.logger.exception(f"Error editing original response in show_ocr_settings: {e_edit}")
-                    await interaction.followup.send(embed=embed, view=view, ephemeral=True)
-            else:
-                await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
-
-        except sqlite3.Error as db_err:
-            cog.logger.exception(f"Database error in show_ocr_settings: {db_err}")
-            error_message = f"{theme.deniedIcon} A database error occurred while loading OCR settings."
-            if interaction.response.is_done(): await interaction.followup.send(error_message, ephemeral=True)
-            else: await interaction.response.send_message(error_message, ephemeral=True)
-        except Exception as e:
-            cog.logger.exception(f"Error showing OCR settings: {e}")
-            traceback.print_exc()
-            error_message = f"{theme.deniedIcon} An unexpected error occurred while loading OCR settings."
-            if interaction.response.is_done():
-                await interaction.followup.send(error_message, ephemeral=True)
-            else:
-                await interaction.response.send_message(error_message, ephemeral=True)
+    value = (
+        f"{theme.robotIcon} **Solver:** {solver_status}\n"
+        f"{theme.fidIcon} **Validation ID:** {fid_line}\n"
+        f"{theme.chartIcon} **Captcha Submissions:** `{submissions}`\n"
+        f"{theme.verifiedIcon} **Success:** `{s_ok}` \u00b7 {theme.deniedIcon} **Failure:** `{s_fail}`\n"
+        f"{theme.chartIcon} **Server Pass Rate:** `{pass_rate:.1f}%`"
+    )
+    return f"{theme.searchIcon} CAPTCHA Solver (since startup)", value
 
 
-async def update_ocr_settings(cog, interaction, enabled=None):
-    """Update OCR settings in the database and reinitialize the solver if needed."""
+def clear_test_fid(cog):
+    """Remove any configured test FID so validation rotates through random alliance members."""
     try:
-        cog.settings_cursor.execute("SELECT enabled FROM ocr_settings ORDER BY id DESC LIMIT 1")
-        current_settings = cog.settings_cursor.fetchone()
-        current_enabled = current_settings[0] if current_settings else 1
-
-        target_enabled = enabled if enabled is not None else current_enabled
-
-        cog.settings_cursor.execute("""
-            UPDATE ocr_settings SET enabled = ?
-            WHERE id = (SELECT MAX(id) FROM ocr_settings)
-            """, (target_enabled,))
-        if cog.settings_cursor.rowcount == 0:
-            cog.settings_cursor.execute("""
-                INSERT INTO ocr_settings (enabled) VALUES (?)
-                """, (target_enabled,))
+        cog.settings_cursor.execute("DELETE FROM test_fid_settings")
         cog.settings_conn.commit()
-        cog.logger.info(f"GiftOps: Updated OCR settings in DB -> Enabled={target_enabled}")
-
-        message_suffix = "Settings updated."
-
-        if enabled is not None and enabled != current_enabled:
-            message_suffix = f"Solver has been {'enabled' if target_enabled == 1 else 'disabled'}."
-            cog.captcha_solver = None
-            if target_enabled == 1:
-                cog.logger.info("GiftOps: OCR is being enabled/reinitialized...")
-                try:
-                    save_captcha = getattr(cog.bot, 'save_captcha', 0)
-                    cog.captcha_solver = GiftCaptchaSolver(save_images=save_captcha)
-                    if cog.captcha_solver.is_initialized:
-                        cog.logger.info("GiftOps: ONNX solver reinitialized successfully.")
-                        message_suffix += " Solver reinitialized."
-                    else:
-                        cog.logger.error("GiftOps: ONNX solver FAILED to reinitialize.")
-                        message_suffix += " Solver reinitialization failed."
-                        cog.captcha_solver = None
-                        return False, f"CAPTCHA solver settings updated. {message_suffix}"
-                except ImportError as imp_err:
-                    cog.logger.exception(f"GiftOps: ERROR - Reinitialization failed: Missing library {imp_err}")
-                    message_suffix += f" Solver initialization failed (Missing Library: {imp_err})."
-                    cog.captcha_solver = None
-                    return False, f"CAPTCHA solver settings updated. {message_suffix}"
-                except Exception as e:
-                    cog.logger.exception(f"GiftOps: ERROR - Reinitialization failed: {e}")
-                    message_suffix += f" Solver initialization failed ({e})."
-                    cog.captcha_solver = None
-                    return False, f"CAPTCHA solver settings updated. {message_suffix}"
-            else:
-                cog.logger.info("GiftOps: OCR disabled, solver instance removed/kept None.")
-
-        return True, f"CAPTCHA solver settings: {message_suffix}"
-
-    except sqlite3.Error as db_err:
-        cog.logger.exception(f"Database error updating OCR settings: {db_err}")
-        return False, f"Database error updating OCR settings: {db_err}"
+        return True
     except Exception as e:
-        cog.logger.exception(f"Unexpected error updating OCR settings: {e}")
-        return False, f"Unexpected error updating OCR settings: {e}"
+        cog.logger.exception(f"Error clearing test ID: {e}")
+        return False
 
 
 async def show_redemption_priority(cog, interaction: discord.Interaction):
@@ -702,7 +546,7 @@ async def setup_giftcode_auto(cog, interaction: discord.Interaction):
 # View and Modal classes (kept as-is, they use self.cog internally)
 # ---------------------------------------------------------------------------
 
-class TestIDModal(discord.ui.Modal, title="Change Test ID"):
+class TestIDModal(discord.ui.Modal, title="Set Test ID"):
     def __init__(self, cog):
         super().__init__()
         self.cog = cog
@@ -710,72 +554,40 @@ class TestIDModal(discord.ui.Modal, title="Change Test ID"):
         try:
             self.cog.settings_cursor.execute("SELECT test_fid FROM test_fid_settings ORDER BY id DESC LIMIT 1")
             result = self.cog.settings_cursor.fetchone()
-            current_fid = result[0] if result else "45379845"
+            current_fid = result[0] if result and result[0] != "45379845" else ""
         except Exception:
-            current_fid = "45379845"
+            current_fid = ""
 
         self.test_fid = discord.ui.TextInput(
-            label="Enter New Player ID",
-            placeholder="Example: 45379845",
+            label="Player ID (blank = rotate members)",
+            placeholder="Leave blank to validate with random alliance members",
             default=current_fid,
-            required=True,
-            min_length=1,
+            required=False,
             max_length=20
         )
         self.add_item(self.test_fid)
 
     async def on_submit(self, interaction: discord.Interaction):
         try:
-            # Defer the response since we'll make an API call to validate
-            await interaction.response.defer(ephemeral=True)
-
-            new_fid = self.test_fid.value.strip()
-
-            if not new_fid.isdigit():
-                await interaction.followup.send(f"{theme.deniedIcon} Invalid ID format. Please enter a numeric ID.", ephemeral=True)
+            raw = self.test_fid.value.strip()
+            if not raw:
+                self.cog.clear_test_fid()
+                self.cog.logger.info(f"Test FID cleared by {interaction.user.id}; validation will rotate alliance members.")
+            elif not raw.isdigit():
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Invalid ID. Enter a numeric player ID, or leave it blank to rotate alliance members.",
+                    ephemeral=True)
                 return
-
-            is_valid, message = await self.cog.verify_test_fid(new_fid)
-
-            if is_valid:
-                success = await self.cog.update_test_fid(new_fid)
-
-                if success:
-                    embed = discord.Embed(
-                        title=f"{theme.verifiedIcon} Test ID Updated",
-                        description=(
-                            f"**Test ID Configuration**\n"
-                            f"{theme.upperDivider}\n"
-                            f"{theme.fidIcon} **ID:** `{new_fid}`\n"
-                            f"{theme.verifiedIcon} **Status:** Validated\n"
-                            f"{theme.editListIcon} **Action:** Updated in database\n"
-                            f"{theme.lowerDivider}\n"
-                        ),
-                        color=theme.emColor3
-                    )
-                    await interaction.followup.send(embed=embed, ephemeral=True)
-
-                    await self.cog.show_ocr_settings(interaction)
-                else:
-                    await interaction.followup.send(f"{theme.deniedIcon} Failed to update test ID in database. Check logs for details.", ephemeral=True)
             else:
-                embed = discord.Embed(
-                    title=f"{theme.deniedIcon} Invalid Test ID",
-                    description=(
-                        f"**Test ID Validation**\n"
-                        f"{theme.upperDivider}\n"
-                        f"{theme.fidIcon} **ID:** `{new_fid}`\n"
-                        f"{theme.deniedIcon} **Status:** Invalid ID\n"
-                        f"{theme.editListIcon} **Reason:** {message}\n"
-                        f"{theme.lowerDivider}\n"
-                    ),
-                    color=theme.emColor2
-                )
-                await interaction.followup.send(embed=embed, ephemeral=True)
+                await self.cog.update_test_fid(raw)
+                self.cog.logger.info(f"Test FID set to {raw} by {interaction.user.id}.")
 
+            # Refresh the settings menu in place so its solver status shows the new mode.
+            await self.cog.show_settings_menu(interaction)
         except Exception as e:
-            self.cog.logger.exception(f"Error updating test ID: {e}")
-            await interaction.followup.send(f"{theme.deniedIcon} An error occurred: {str(e)}", ephemeral=True)
+            self.cog.logger.exception(f"Error setting test ID: {e}")
+            if not interaction.response.is_done():
+                await interaction.response.send_message(f"{theme.deniedIcon} An error occurred: {str(e)}", ephemeral=True)
 
 
 class RedemptionPriorityView(discord.ui.View):
@@ -980,239 +792,140 @@ class ClearCacheConfirmView(discord.ui.View):
             item.disabled = True
 
 
-class OCRSettingsView(discord.ui.View):
-    def __init__(self, cog, enabled, onnx_available):
+
+# ---------------------------------------------------------------------------
+# Redemption Summary — per-alliance opt-in channel summary after redemptions
+# ---------------------------------------------------------------------------
+
+async def show_redemption_summary(cog, interaction: discord.Interaction):
+    """Per-alliance config for the post-redemption summary embed."""
+    alliances, _ = PermissionManager.get_admin_alliances(
+        interaction.user.id, interaction.guild_id or 0
+    )
+    if not alliances:
+        msg = f"{theme.deniedIcon} You have no alliances to configure."
+        if interaction.response.is_done():
+            await interaction.followup.send(msg, ephemeral=True)
+        else:
+            await interaction.response.send_message(msg, ephemeral=True)
+        return
+    view = RedemptionSummaryView(cog, interaction.user.id, alliances)
+    await safe_edit_message(interaction, embed=view.build_embed(), view=view, content=None)
+    view.message = await interaction.original_response()
+
+
+class RedemptionSummaryView(discord.ui.View):
+    """Pick an alliance, then toggle whether/what its redemption summary posts."""
+
+    def __init__(self, cog, user_id: int, alliances):
         super().__init__(timeout=7200)
         self.cog = cog
-        self.enabled = enabled
-        self.onnx_available = onnx_available
-        self.disable_controls = not onnx_available
+        self.user_id = user_id
+        self.alliances = alliances            # [(alliance_id, name), ...]
+        self.selected_id = None
+        self.message = None
+        self._build_components()
 
-        # Row 0: Enable/Disable Button, Test Button
-        self.enable_ocr_button_item = discord.ui.Button(
-            emoji=f"{theme.verifiedIcon}" if self.enabled == 1 else "🚫",
-            custom_id="enable_ocr", row=0,
-            label="Disable CAPTCHA Solver" if self.enabled == 1 else "Enable CAPTCHA Solver",
-            style=discord.ButtonStyle.danger if self.enabled == 1 else discord.ButtonStyle.success,
-            disabled=self.disable_controls
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_interaction_user(interaction, self.user_id)
+
+    def _settings(self):
+        from .gift_redemption import get_summary_settings
+        return get_summary_settings(self.cog, self.selected_id) if self.selected_id else None
+
+    def _build_components(self):
+        self.clear_items()
+        options = [
+            discord.SelectOption(
+                label=name[:100], value=str(aid),
+                default=str(aid) == str(self.selected_id),
+            )
+            for aid, name in self.alliances[:25]
+        ]
+        select = discord.ui.Select(placeholder="Select an alliance", options=options, row=0)
+        select.callback = self._on_alliance
+        self.add_item(select)
+
+        s = self._settings()
+        if s is not None:
+            self._add_toggle("Summary", theme.redeemIcon, bool(s["enabled"]), self._toggle_enabled, row=1)
+            if s["enabled"]:
+                self._add_toggle("Successful", theme.verifiedIcon, bool(s["success"]), self._toggle_success, row=2)
+                self._add_toggle("Already Redeemed", theme.giftIcon, bool(s["already"]), self._toggle_already, row=2)
+                self._add_toggle("Failed", theme.deniedIcon, bool(s["failed"]), self._toggle_failed, row=2)
+
+        back = discord.ui.Button(label="Back", emoji=f"{theme.backIcon}", style=discord.ButtonStyle.secondary, row=3)
+        back.callback = self._back
+        self.add_item(back)
+
+    def _add_toggle(self, label, emoji, enabled, callback, row):
+        btn = discord.ui.Button(
+            label=f"{label}: {'On' if enabled else 'Off'}",
+            emoji=f"{emoji}",
+            style=discord.ButtonStyle.success if enabled else discord.ButtonStyle.secondary,
+            row=row,
         )
-        self.enable_ocr_button_item.callback = self.enable_ocr_button
-        self.add_item(self.enable_ocr_button_item)
+        btn.callback = callback
+        self.add_item(btn)
 
-        self.test_ocr_button_item = discord.ui.Button(
-            label="Test CAPTCHA Solver", style=discord.ButtonStyle.secondary, emoji=f"{theme.testIcon}",
-            custom_id="test_ocr", row=0,
-            disabled=self.disable_controls
+    def build_embed(self) -> discord.Embed:
+        desc = (
+            "Choose an alliance, then turn its post-redemption summary on or off "
+            "and pick which results it lists.\n\n"
+            "When on, the bot posts one embed in the gift channel after each code "
+            "finishes for that alliance, listing the buckets you enable.\n"
         )
-        self.test_ocr_button_item.callback = self.test_ocr_button
-        self.add_item(self.test_ocr_button_item)
-
-        # Add the Change Test ID Button
-        self.change_test_fid_button_item = discord.ui.Button(
-            label="Change Test ID", style=discord.ButtonStyle.primary, emoji=f"{theme.refreshIcon}",
-            custom_id="change_test_fid", row=0,
-            disabled=self.disable_controls
-        )
-        self.change_test_fid_button_item.callback = self.change_test_fid_button
-        self.add_item(self.change_test_fid_button_item)
-
-        # Add the Clear Redemption Cache Button
-        self.clear_cache_button_item = discord.ui.Button(
-            label="Clear Redemption Cache", style=discord.ButtonStyle.danger, emoji=f"{theme.trashIcon}",
-            custom_id="clear_redemption_cache", row=1,
-            disabled=self.disable_controls
-        )
-        self.clear_cache_button_item.callback = self.clear_redemption_cache_button
-        self.add_item(self.clear_cache_button_item)
-
-
-    async def change_test_fid_button(self, interaction: discord.Interaction):
-        """Handle the change test ID button click."""
-        if not self.onnx_available:
-            await interaction.response.send_message(f"{theme.deniedIcon} Required library (onnxruntime) is not installed or failed to load.", ephemeral=True)
-            return
-        await interaction.response.send_modal(TestIDModal(self.cog))
-
-    async def enable_ocr_button(self, interaction: discord.Interaction):
-        if not self.onnx_available:
-            await interaction.response.send_message(f"{theme.deniedIcon} Required library (onnxruntime) is not installed or failed to load.", ephemeral=True)
-            return
-
-        await interaction.response.defer(ephemeral=True)
-        new_enabled = 1 if self.enabled == 0 else 0
-        success, message = await self.cog.update_ocr_settings(interaction, enabled=new_enabled)
-        await self.cog.show_ocr_settings(interaction)
-
-    async def test_ocr_button(self, interaction: discord.Interaction):
-        logger = self.cog.logger
-        user_id = interaction.user.id
-        current_time = time.time()
-
-        if not self.onnx_available:
-            await interaction.response.send_message(f"{theme.deniedIcon} Required library (onnxruntime) is not installed or failed to load.", ephemeral=True)
-            return
-        if not self.cog.captcha_solver or not self.cog.captcha_solver.is_initialized:
-            await interaction.response.send_message(f"{theme.deniedIcon} CAPTCHA solver is not initialized. Ensure OCR is enabled.", ephemeral=True)
-            return
-
-        last_test_time = self.cog.test_captcha_cooldowns.get(user_id, 0)
-        if current_time - last_test_time < self.cog.test_captcha_delay:
-            remaining_time = int(self.cog.test_captcha_delay - (current_time - last_test_time))
-            await interaction.response.send_message(f"{theme.deniedIcon} Please wait {remaining_time} more seconds before testing again.", ephemeral=True)
-            return
-
-        await interaction.response.defer(ephemeral=True)
-        logger.info(f"[Test Button] User {user_id} triggered test.")
-        self.cog.test_captcha_cooldowns[user_id] = current_time
-
-        captcha_image_base64 = None
-        image_bytes = None
-        error = None
-        captcha_code = None
-        success = False
-        method = "N/A"
-        confidence = 0.0
-        solve_duration = 0.0
-        test_fid = self.cog.get_test_fid()
-        session = None
-
-        try:
-            logger.info(f"[Test Button] First logging in with test ID {test_fid}...")
-            session, response_stove_info = await self.cog.get_stove_info_wos(test_fid)
-
-            try:
-                player_info_json = response_stove_info.json()
-                if player_info_json.get("msg") != "success":
-                    logger.error(f"[Test Button] Login failed for test ID {test_fid}: {player_info_json.get('msg')}")
-                    await interaction.followup.send(f"{theme.deniedIcon} Login failed with test ID {test_fid}. Please check if the ID is valid.", ephemeral=True)
-                    return
-                logger.info(f"[Test Button] Successfully logged in with test ID {test_fid}")
-            except Exception as json_err:
-                logger.error(f"[Test Button] Error parsing login response: {json_err}")
-                await interaction.followup.send(f"{theme.deniedIcon} Error processing login response.", ephemeral=True)
-                return
-
-            logger.info(f"[Test Button] Fetching captcha for test ID {test_fid} using established session...")
-            captcha_image_base64, error = await self.cog.fetch_captcha(test_fid, session)
-            logger.info(f"[Test Button] Captcha fetch result: Error='{error}', HasImage={captcha_image_base64 is not None}")
-
-            if error:
-                await interaction.followup.send(f"{theme.deniedIcon} Error fetching test captcha from the API: `{error}`", ephemeral=True)
-                return
-
-            if captcha_image_base64:
-                try:
-                    if captcha_image_base64.startswith("data:image"):
-                        img_b64_data = captcha_image_base64.split(",", 1)[1]
-                    else:
-                        img_b64_data = captcha_image_base64
-                    image_bytes = base64.b64decode(img_b64_data)
-                    logger.info("[Test Button] Successfully decoded base64 image.")
-                except Exception as decode_err:
-                    logger.error(f"[Test Button] Failed to decode base64 image: {decode_err}")
-                    await interaction.followup.send(f"{theme.deniedIcon} Failed to decode captcha image data.", ephemeral=True)
-                    return
+        s = self._settings()
+        if s is not None:
+            name = next((n for a, n in self.alliances if str(a) == str(self.selected_id)), self.selected_id)
+            if not s["enabled"]:
+                state = f"{theme.deniedIcon} Off"
             else:
-                logger.error("[Test Button] Captcha fetch returned no image data.")
-                await interaction.followup.send(f"{theme.deniedIcon} Failed to retrieve captcha image data from API.", ephemeral=True)
-                return
-
-            if image_bytes:
-                logger.info("[Test Button] Solving fetched captcha...")
-                start_solve_time = time.time()
-                captcha_code, success, method, confidence, _ = await self.cog.captcha_solver.solve_captcha(
-                    image_bytes, fid=f"test-{user_id}", attempt=0
-                )
-                solve_duration = time.time() - start_solve_time
-                log_confidence_str = f'{confidence:.2f}' if isinstance(confidence, float) else 'N/A'
-                logger.info(f"[Test Button] Solve result: Success={success}, Code='{captcha_code}', Method='{method}', Conf={log_confidence_str}. Duration: {solve_duration:.2f}s")
-            else:
-                 logger.error("[Test Button] Logic error: image_bytes is None before solving.")
-                 await interaction.followup.send(f"{theme.deniedIcon} Internal error before solving captcha.", ephemeral=True)
-                 return
-
-            confidence_str = f'{confidence:.2f}' if isinstance(confidence, float) else 'N/A'
-            embed = discord.Embed(
-                title=f"{theme.searchIcon} CAPTCHA Solver Test Results (ONNX)",
-                description=(
-                    f"**Test Summary**\n{theme.upperDivider}\n"
-                    f"{theme.robotIcon} **OCR Success:** {f'{theme.verifiedIcon} Yes' if success else f'{theme.deniedIcon} No'}\n"
-                    f"{theme.searchIcon} **Recognized Code:** `{captcha_code if success and captcha_code else 'N/A'}`\n"
-                    f"{theme.chartIcon} **Confidence:** `{confidence_str}`\n"
-                    f"{theme.timeIcon} **Solve Time:** `{solve_duration:.2f}s`\n"
-                    f"{theme.lowerDivider}\n"
-                ), color=theme.emColor3 if success else discord.Color.red()
-            )
-
-            await interaction.followup.send(embed=embed, ephemeral=True)
-            logger.info(f"[Test Button] Test completed for user {user_id}.")
-
-        except requests.exceptions.ConnectionError:
-            logger.warning(f"[Test Button] Connection error for user {user_id}. WOS API may be unavailable.")
-            try:
-                await interaction.followup.send(f"{theme.deniedIcon} Connection error: Unable to reach WOS API. Please check your internet connection.", ephemeral=True)
-            except Exception:
-                pass
-        except requests.exceptions.Timeout:
-            logger.warning(f"[Test Button] Timeout for user {user_id}. WOS API may be slow.")
-            try:
-                await interaction.followup.send(f"{theme.deniedIcon} Connection error: Request timed out. WOS API may be overloaded or unavailable.", ephemeral=True)
-            except Exception:
-                pass
-        except requests.exceptions.RequestException as e:
-            logger.warning(f"[Test Button] Request error for user {user_id}: {type(e).__name__}")
-            try:
-                await interaction.followup.send(f"{theme.deniedIcon} Connection error: {type(e).__name__}. Please try again later.", ephemeral=True)
-            except Exception:
-                pass
-        except Exception as e:
-            logger.exception(f"[Test Button] UNEXPECTED Error during test for user {user_id}: {e}")
-            try:
-                await interaction.followup.send(f"{theme.deniedIcon} An unexpected error occurred during the test: `{e}`. Please check the bot logs.", ephemeral=True)
-            except Exception as followup_err:
-                logger.error(f"[Test Button] Failed to send final error followup to user {user_id}: {followup_err}")
-        finally:
-            if session:
-                session.close()
-
-    async def clear_redemption_cache_button(self, interaction: discord.Interaction):
-        """Handle the clear redemption cache button click."""
-        if not self.onnx_available:
-            await interaction.response.send_message(f"{theme.deniedIcon} Required library (onnxruntime) is not installed or failed to load.", ephemeral=True)
-            return
-
-        # Create confirmation embed
-        embed = discord.Embed(
-            title=f"{theme.warnIcon} Clear Redemption Cache",
-            description=(
-                "This will **permanently delete** all gift code redemption records from the database.\n\n"
-                "**What this does:**\n"
-                "• Removes all entries from the `user_giftcodes` table\n"
-                "• Allows users to attempt redeeming gift codes again\n"
-                "• Useful for development testing and image collection\n\n"
-                "**Warning:** This action cannot be undone!"
-            ),
-            color=discord.Color.orange()
+                picked = [lbl for lbl, on in (
+                    ("Successful", s["success"]), ("Already Redeemed", s["already"]), ("Failed", s["failed"])
+                ) if on]
+                state = f"{theme.verifiedIcon} On — " + (", ".join(picked) if picked else "no buckets selected yet")
+            desc += f"\n{theme.upperDivider}\n**{name}:** {state}\n{theme.lowerDivider}"
+        return discord.Embed(
+            title=f"{theme.redeemIcon} Redemption Summary",
+            description=desc,
+            color=theme.emColor1,
         )
 
-        # Get current count for display
-        try:
-            self.cog.cursor.execute("SELECT COUNT(*) FROM user_giftcodes")
-            current_count = self.cog.cursor.fetchone()[0]
-            embed.add_field(
-                name=f"{theme.chartIcon} Current Records",
-                value=f"{current_count:,} redemption records will be deleted",
-                inline=False
-            )
-        except Exception as e:
-            self.cog.logger.error(f"Error getting user_giftcodes count: {e}")
-            embed.add_field(
-                name=f"{theme.chartIcon} Current Records",
-                value="Unable to count records",
-                inline=False
-            )
+    async def _refresh(self, interaction: discord.Interaction):
+        self._build_components()
+        await safe_edit_message(interaction, embed=self.build_embed(), view=self, content=None)
 
-        # Create confirmation view
-        confirm_view = ClearCacheConfirmView(self.cog)
-        await interaction.response.send_message(embed=embed, view=confirm_view, ephemeral=True)
+    async def _on_alliance(self, interaction: discord.Interaction):
+        self.selected_id = int(interaction.data["values"][0])
+        await self._refresh(interaction)
+
+    async def _set(self, interaction, **kwargs):
+        from .gift_redemption import set_summary_settings
+        set_summary_settings(self.cog, self.selected_id, **kwargs)
+        await self._refresh(interaction)
+
+    async def _toggle_enabled(self, interaction):
+        s = self._settings()
+        turning_on = not s["enabled"]
+        kwargs = {"enabled": turning_on}
+        # Sensible default on first enable: show Failed (the actionable bucket).
+        if turning_on and not (s["success"] or s["already"] or s["failed"]):
+            kwargs["failed"] = True
+        await self._set(interaction, **kwargs)
+
+    async def _toggle_success(self, interaction):
+        await self._set(interaction, success=not self._settings()["success"])
+
+    async def _toggle_already(self, interaction):
+        await self._set(interaction, already=not self._settings()["already"])
+
+    async def _toggle_failed(self, interaction):
+        await self._set(interaction, failed=not self._settings()["failed"])
+
+    async def _back(self, interaction: discord.Interaction):
+        await self.cog.show_settings_menu(interaction)
+
+    async def on_timeout(self):
+        await notify_view_expired(self, "redemption summary settings")
 

--- a/cogs/gift_views.py
+++ b/cogs/gift_views.py
@@ -185,7 +185,7 @@ async def delete_gift_code(cog, interaction: discord.Interaction):
             elif validation_status == 'invalid':
                 status_display = f"{theme.deniedIcon} Invalid"
             elif validation_status == 'pending':
-                status_display = f"{theme.warnIcon} Pending"
+                status_display = f"{theme.warnIcon} Validating"
             else:
                 status_display = f"{theme.infoIcon} Unknown"
 
@@ -373,12 +373,21 @@ async def show_settings_menu(cog, interaction: discord.Interaction):
             f"└ Change the order in which alliances auto-redeem new gift codes\n\n"
             f"{theme.searchIcon} **Channel History Scan**\n"
             f"└ Scan for gift codes in existing messages in a gift channel\n\n"
-            f"{theme.settingsIcon} **CAPTCHA Settings**\n"
-            f"└ Configure CAPTCHA-solver related settings and image saving\n"
+            f"{theme.redeemIcon} **Redemption Summary**\n"
+            f"└ Per-alliance: post a results summary in the channel after redemptions\n\n"
+            f"{theme.fidIcon} **Set Test ID**\n"
+            f"└ Player ID used to validate codes (blank = rotate alliance members)\n\n"
+            f"{theme.trashIcon} **Clear Redemption Cache**\n"
+            f"└ Wipe redemption records so codes can be re-redeemed\n"
             f"{theme.lowerDivider}"
         ),
         color=theme.emColor1
     )
+
+    # Captcha solver status/stats (moved here from the removed CAPTCHA menu).
+    from .gift_settings import build_solver_status_field
+    _name, _value = build_solver_status_field(cog)
+    settings_embed.add_field(name=_name, value=_value, inline=False)
 
     settings_view = SettingsMenuView(cog, interaction.user.id, is_global)
 
@@ -408,15 +417,19 @@ class CreateGiftCodeModal(discord.ui.Modal):
 
     async def on_submit(self, interaction: discord.Interaction):
         logger = self.cog.logger
-        await interaction.response.defer(ephemeral=True)
+        # thinking=True makes this a NEW ephemeral message; without it a modal submit
+        # just edits the menu the modal was opened from (ephemeral flag is ignored).
+        await interaction.response.defer(ephemeral=True, thinking=True)
 
         code = self.cog.clean_gift_code(self.giftcode.value)
         logger.info(f"[CreateGiftCodeModal] Code entered: {code}")
         final_embed = discord.Embed(title=f"{theme.giftIcon} Gift Code Creation Result")
 
-        # Check if code already exists
-        self.cog.cursor.execute("SELECT 1 FROM gift_codes WHERE giftcode = ?", (code,))
-        if self.cog.cursor.fetchone():
+        # A code we hold as 'invalid' that an admin re-adds is a reactivation candidate:
+        # re-validate it rather than bailing. Other stored statuses stay "already exists".
+        self.cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (code,))
+        row = self.cog.cursor.fetchone()
+        if row and row[0] != 'invalid':
             logger.info(f"[CreateGiftCodeModal] Code {code} already exists in DB.")
             final_embed.title = f"{theme.infoIcon} Gift Code Exists"
             final_embed.description = (
@@ -426,7 +439,8 @@ class CreateGiftCodeModal(discord.ui.Modal):
                 f"{theme.lowerDivider}\n"
             )
             final_embed.color = theme.emColor1
-        else: # Validate the code immediately
+        else: # Validate the code immediately (force a live re-probe for a reactivation candidate)
+            was_invalid = row is not None and row[0] == 'invalid'
             logger.info(f"[CreateGiftCodeModal] Validating code {code} before adding to DB.")
 
             validation_embed = discord.Embed(
@@ -436,7 +450,7 @@ class CreateGiftCodeModal(discord.ui.Modal):
             )
             await interaction.edit_original_response(embed=validation_embed)
 
-            is_valid, validation_msg = await self.cog.validate_gift_code_immediately(code, "button")
+            is_valid, validation_msg = await self.cog.validate_gift_code_immediately(code, "button", force=was_invalid)
 
             if is_valid: # Valid code - send to API and add to DB
                 logger.info(f"[CreateGiftCodeModal] Code '{code}' validated successfully.")
@@ -444,18 +458,33 @@ class CreateGiftCodeModal(discord.ui.Modal):
                 if hasattr(self.cog, 'api') and self.cog.api:
                     asyncio.create_task(self.cog.api.add_giftcode(code))
 
+                if was_invalid:
+                    # Genuine reactivation: clear old redemptions so members can claim again.
+                    try:
+                        self.cog.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ?", (code,))
+                        self.cog.conn.commit()
+                        logger.info(f"[CreateGiftCodeModal] 🔄 REACTIVATION: '{code}' re-validated valid; cleared old redemption records")
+                    except Exception as e:
+                        logger.error(f"[CreateGiftCodeModal] Error clearing reactivation history for '{code}': {e}")
+
                 await self.cog._process_auto_use(code)
 
                 self.cog.cursor.execute("SELECT COUNT(*) FROM giftcodecontrol WHERE status = 1")
                 auto_count = self.cog.cursor.fetchone()[0]
 
-                final_embed.title = f"{theme.verifiedIcon} Gift Code Validated"
+                if auto_count:
+                    auto_redeem_line = f"{theme.refreshIcon} **Auto-redemption:** Queued for {auto_count} Alliances"
+                else:
+                    auto_redeem_line = f"{theme.refreshIcon} **Auto-redemption** is not enabled"
+
+                action_line = "Reactivated - re-validated and sent to API" if was_invalid else "Added to database and sent to API"
+                final_embed.title = f"{theme.verifiedIcon} Gift Code {'Reactivated' if was_invalid else 'Validated'}"
                 final_embed.description = (
                     f"**Gift Code Details**\n{theme.upperDivider}\n"
                     f"{theme.giftIcon} **Gift Code:** `{code}`\n"
                     f"{theme.verifiedIcon} **Status:** {validation_msg}\n"
-                    f"{theme.editListIcon} **Action:** Added to database and sent to API\n"
-                    f"{theme.refreshIcon} **Auto-redemption:** {'Queued for ' + str(auto_count) + ' alliance(s)' if auto_count else 'Disabled'}\n"
+                    f"{theme.editListIcon} **Action:** {action_line}\n"
+                    f"{auto_redeem_line}\n"
                     f"{theme.lowerDivider}\n"
                 )
                 final_embed.color = theme.emColor3
@@ -484,12 +513,17 @@ class CreateGiftCodeModal(discord.ui.Modal):
                     )
                     self.cog.conn.commit()
 
-                    final_embed.title = f"{theme.warnIcon} Gift Code Added (Pending)"
+                    # Re-check ASAP instead of waiting for the periodic loop.
+                    self.cog.schedule_revalidation(code, "button")
+
+                    from . import gift_redemption
+                    final_embed.title = f"{theme.warnIcon} Gift Code Added (Validating)"
                     final_embed.description = (
                         f"**Gift Code Details**\n{theme.upperDivider}\n"
                         f"{theme.giftIcon} **Gift Code:** `{code}`\n"
                         f"{theme.warnIcon} **Status:** {validation_msg}\n"
-                        f"{theme.editListIcon} **Action:** Added for later validation\n"
+                        f"{theme.editListIcon} **Action:** Saved - re-checking automatically\n"
+                        f"{gift_redemption.PENDING_REVALIDATION_NOTICE}\n"
                         f"{theme.lowerDivider}\n"
                     )
                     final_embed.color = theme.emColor4
@@ -847,6 +881,18 @@ class GiftView(discord.ui.View):
         await self.cog.show_settings_menu(interaction)
 
     @discord.ui.button(
+        label="Redemption History",
+        style=discord.ButtonStyle.secondary,
+        custom_id="redeem_history",
+        emoji=f"{theme.archiveIcon}",
+        row=1
+    )
+    async def redeem_history_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await check_interaction_user(interaction, self.original_user_id):
+            return
+        await self.cog.show_redeem_results(interaction)
+
+    @discord.ui.button(
         label="Delete Gift Code",
         emoji=f"{theme.trashIcon}",
         style=discord.ButtonStyle.danger,
@@ -895,7 +941,7 @@ class SettingsMenuView(discord.ui.View):
         if not is_global:
             for child in self.children:
                 if isinstance(child, discord.ui.Button) and child.label in [
-                    "Redemption Priority", "CAPTCHA Settings"
+                    "Redemption Priority", "Set Test ID", "Clear Redemption Cache"
                 ]:
                     child.disabled = True
 
@@ -948,23 +994,59 @@ class SettingsMenuView(discord.ui.View):
         await self.cog.channel_history_scan(interaction)
 
     @discord.ui.button(
-        label="CAPTCHA Settings",
+        label="Redemption Summary",
         style=discord.ButtonStyle.secondary,
-        custom_id="captcha_settings",
-        emoji=f"{theme.settingsIcon}",
+        custom_id="redemption_summary",
+        emoji=f"{theme.redeemIcon}",
         row=1
     )
-    async def captcha_settings_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def redemption_summary_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not await check_interaction_user(interaction, self.original_user_id):
             return
-        await self.cog.show_ocr_settings(interaction)
+        await self.cog.show_redemption_summary(interaction)
+
+    @discord.ui.button(
+        label="Set Test ID",
+        style=discord.ButtonStyle.secondary,
+        custom_id="set_test_fid",
+        emoji=f"{theme.fidIcon}",
+        row=1
+    )
+    async def set_test_fid_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await check_interaction_user(interaction, self.original_user_id):
+            return
+        from .gift_settings import TestIDModal
+        await interaction.response.send_modal(TestIDModal(self.cog))
+
+    @discord.ui.button(
+        label="Clear Redemption Cache",
+        style=discord.ButtonStyle.danger,
+        custom_id="clear_redemption_cache",
+        emoji=f"{theme.trashIcon}",
+        row=2
+    )
+    async def clear_redemption_cache_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await check_interaction_user(interaction, self.original_user_id):
+            return
+        from .gift_settings import ClearCacheConfirmView
+        embed = discord.Embed(
+            title=f"{theme.warnIcon} Clear Redemption Cache",
+            description=(
+                f"{theme.upperDivider}\n"
+                f"This permanently deletes **all** gift code redemption records, letting users redeem every code again.\n\n"
+                f"{theme.warnIcon} This cannot be undone.\n"
+                f"{theme.lowerDivider}"
+            ),
+            color=theme.emColor2
+        )
+        await interaction.response.send_message(embed=embed, view=ClearCacheConfirmView(self.cog), ephemeral=True)
 
     @discord.ui.button(
         label="Back",
         style=discord.ButtonStyle.secondary,
         custom_id="back_to_main",
         emoji=f"{theme.backIcon}",
-        row=2
+        row=3
     )
     async def back_to_main_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not await check_interaction_user(interaction, self.original_user_id):

--- a/main.py
+++ b/main.py
@@ -1176,6 +1176,16 @@ if __name__ == "__main__":
             conn_settings.execute("""CREATE INDEX IF NOT EXISTS idx_permission_audit_timestamp
                 ON permission_audit_log(timestamp DESC)""")
 
+            # Per-alliance opt-in channel summary posted after each redemption.
+            # No row = disabled (default). Buckets choose what the summary lists.
+            conn_settings.execute("""CREATE TABLE IF NOT EXISTS redemption_summary_settings (
+                alliance_id INTEGER PRIMARY KEY,
+                enabled INTEGER NOT NULL DEFAULT 0,
+                show_success INTEGER NOT NULL DEFAULT 0,
+                show_already INTEGER NOT NULL DEFAULT 0,
+                show_failed INTEGER NOT NULL DEFAULT 1
+            )""")
+
         with connections["conn_users"] as conn_users:
             conn_users.execute("""CREATE TABLE IF NOT EXISTS users (
                 fid INTEGER PRIMARY KEY,
@@ -1210,12 +1220,17 @@ if __name__ == "__main__":
             )""")
             
             conn_giftcode.execute("""CREATE TABLE IF NOT EXISTS user_giftcodes (
-                fid INTEGER, 
-                giftcode TEXT, 
-                status TEXT, 
+                fid INTEGER,
+                giftcode TEXT,
+                status TEXT,
+                last_attempt_at TEXT,
                 PRIMARY KEY (fid, giftcode),
                 FOREIGN KEY (giftcode) REFERENCES gift_codes (giftcode)
             )""")
+            # Upgrade path: per-account attempt timestamp for the redeem-results viewer.
+            uc_cols = [row[1] for row in conn_giftcode.execute("PRAGMA table_info(user_giftcodes)").fetchall()]
+            if "last_attempt_at" not in uc_cols:
+                conn_giftcode.execute("ALTER TABLE user_giftcodes ADD COLUMN last_attempt_at TEXT")
 
         with connections["conn_alliance"] as conn_alliance:
             conn_alliance.execute("""CREATE TABLE IF NOT EXISTS alliancesettings (


### PR DESCRIPTION
### Redemption Summary
- Posts a per-ally summary as up to three messages after each redemption run in the gift code channel
- Optional feature (off by default) accessible via /settings -> Gift Codes -> Settings -> Redemption Summary
- Choose which results should be posted - redeemed, already redeemed and/or failed
- Each summary post is silent and shows failures including IDs grouped by reason

### Redemption History
- New Redemption History button under /settings -> Gift Codes button opens a paginated screen showing which accounts redeemed/already redeemed/failed to redeem gift codes.
- Provides a view into historical redemption records for bot admins, to complement the publicly posted records shown with the Redemption Summary feature.

### CAPTCHA Settings
- Removed the CAPTCHA Settings menu including the enable/disable toggle and test button (CAPTCHA Solver is always on)
- Moved Set Test ID (clearing it now removes the test ID) and Clear Redemption Cache onto the Gift Code Settings menu, with solver status/stats shown inline
- Channel History Scan now auto-redeems and shares any valid codes it finds

### Fixes
- Funnel all validation through one serialized, per-ID rate-spaced gate with backoff >=60s per ID
- Changed confusing wording Pending -> Validating in the redemption embeds to clarify that codes are in the process of validation
- Rotate to alliance-member IDs when the primary ID is inconclusive, so a dead/throttled test ID can't strand codes as Validating
- Periodic loop now locks per-code instead of per-run and yields to any new-code validation; this should help fix the issue with Pending validations
- Fix issue related to channel-discovered codes not being shared with the distribution API
- Fix issue with code reactivation not working properly (for previously-invalidated codes)